### PR TITLE
Make it possible to manually run VCPKG cache action

### DIFF
--- a/.github/workflows/cache_vcpkg.yml
+++ b/.github/workflows/cache_vcpkg.yml
@@ -62,16 +62,12 @@ jobs:
       - name: Checkout Arrow
         uses: actions/checkout@v2
         with:
-          repository: ${{ github.event.inputs.arrow-repo }}
+          repository: ${{ github.event.inputs.arrow-repo || "apache/arrow"}}
           path: arrow
-          ref: ${{ github.event.inputs.arrow-ref}}
-      - run: |
-          ls
-          ls arrow
+          ref: ${{ github.event.inputs.arrow-ref || "master"}}
       - name: Retrieve VCPKG version from arrow/.env
         shell: bash
         run: |
-          pwd
           if [ -z "${{ github.event.inputs.vcpkg-version }}" ]; then
             vcpkg_version=$(cat "arrow/.env" | grep "VCPKG" | cut -d "=" -f2 | tr -d '"')
           else

--- a/.github/workflows/cache_vcpkg.yml
+++ b/.github/workflows/cache_vcpkg.yml
@@ -18,6 +18,20 @@
 name: Crossbow Cache
 
 on:
+  workflow_dispatch:
+    inputs:
+      vcpkg-version:
+        description: 'VCPKG Version to use in building the cache.'
+        required: true
+        default: ''
+      arrow-repo:
+        description: 'Repository to checkout arrow from.'
+        required: true
+        default: 'apache/arrow'
+      arrow-ref:
+        description: 'Ref to checkout from arrow-repo.'
+        required: true
+        default: 'master'
   # perhaps daily one for keeping the cache warm
   push:
     paths:
@@ -48,14 +62,19 @@ jobs:
       - name: Checkout Arrow
         uses: actions/checkout@v2
         with:
-          repository: apache/arrow
+          repository: ${{ github.event.inputs.arrow-repo }}
           path: arrow
-          ref: master
+          ref: ${{ github.event.inputs.arrow-ref}}
 
       - name: Retrieve VCPKG version from arrow/.env
         shell: bash
         run: |
-          vcpkg_version=$(cat "arrow/.env" | grep "VCPKG" | cut -d "=" -f2 | tr -d '"')
+          if [ -z "${{ github.event.inputs.vcpkg-version }}"]; then
+            vcpkg_version=$(cat "arrow/.env" | grep "VCPKG" | cut -d "=" -f2 | tr -d '"')
+          else
+            vcpkg_version=${{ github.event.inputs.vcpkg-version }}
+          fi
+          
           echo "VCPKG_VERSION=$vcpkg_version" >> $GITHUB_ENV
 
       - name: Install System Dependencies

--- a/.github/workflows/cache_vcpkg.yml
+++ b/.github/workflows/cache_vcpkg.yml
@@ -65,7 +65,7 @@ jobs:
           repository: ${{ github.event.inputs.arrow-repo }}
           path: arrow
           ref: ${{ github.event.inputs.arrow-ref}}
-
+      - run: ls
       - name: Retrieve VCPKG version from arrow/.env
         shell: bash
         run: |

--- a/.github/workflows/cache_vcpkg.yml
+++ b/.github/workflows/cache_vcpkg.yml
@@ -62,9 +62,9 @@ jobs:
       - name: Checkout Arrow
         uses: actions/checkout@v2
         with:
-          repository: ${{ github.event.inputs.arrow-repo || "apache/arrow"}}
+          repository: ${{ github.event.inputs.arrow-repo || 'apache/arrow'}}
           path: arrow
-          ref: ${{ github.event.inputs.arrow-ref || "master"}}
+          ref: ${{ github.event.inputs.arrow-ref || 'master'}}
       - name: Retrieve VCPKG version from arrow/.env
         shell: bash
         run: |

--- a/.github/workflows/cache_vcpkg.yml
+++ b/.github/workflows/cache_vcpkg.yml
@@ -65,10 +65,13 @@ jobs:
           repository: ${{ github.event.inputs.arrow-repo }}
           path: arrow
           ref: ${{ github.event.inputs.arrow-ref}}
-      - run: ls
+      - run: |
+          ls
+          ls arrow
       - name: Retrieve VCPKG version from arrow/.env
         shell: bash
         run: |
+          pwd
           if [ -z "${{ github.event.inputs.vcpkg-version }}" ]; then
             vcpkg_version=$(cat "arrow/.env" | grep "VCPKG" | cut -d "=" -f2 | tr -d '"')
           else

--- a/.github/workflows/cache_vcpkg.yml
+++ b/.github/workflows/cache_vcpkg.yml
@@ -69,12 +69,12 @@ jobs:
       - name: Retrieve VCPKG version from arrow/.env
         shell: bash
         run: |
-          if [ -z "${{ github.event.inputs.vcpkg-version }}"]; then
+          if [ -z "${{ github.event.inputs.vcpkg-version }}" ]; then
             vcpkg_version=$(cat "arrow/.env" | grep "VCPKG" | cut -d "=" -f2 | tr -d '"')
           else
-            vcpkg_version=${{ github.event.inputs.vcpkg-version }}
+            vcpkg_version="${{ github.event.inputs.vcpkg-version }}"
           fi
-          
+
           echo "VCPKG_VERSION=$vcpkg_version" >> $GITHUB_ENV
 
       - name: Install System Dependencies


### PR DESCRIPTION
These changes make it possible to run the cache workflow with a custom vcpkg version and repo to test cache creation on new versions e.g. something like https://github.com/apache/arrow/pull/12893
