### PR TITLE
Action for building windows vs2017 base images

### DIFF
--- a/.github/workflows/cache_vcpkg.yml
+++ b/.github/workflows/cache_vcpkg.yml
@@ -73,7 +73,6 @@ jobs:
           else
             vcpkg_version="${{ github.event.inputs.vcpkg-version }}"
           fi
-          
           echo "VCPKG_VERSION=$vcpkg_version" >> $GITHUB_ENV
 
       - name: Install System Dependencies

--- a/.github/workflows/windows_docker.yml
+++ b/.github/workflows/windows_docker.yml
@@ -1,0 +1,83 @@
+name: Build Windows Base Images
+on:
+  workflow_dispatch:
+    inputs:
+     vcpkg-version:
+       description: 'VCPKG Version to use in building the images.'
+       default: ''
+     arrow-repo:
+       description: 'Repository to checkout arrow from.'
+       required: true
+       default: 'apache/arrow'
+     arrow-ref:
+       description: 'Ref to checkout from arrow-repo.'
+       required: true
+       default: 'master'
+
+jobs:
+  build:
+    name: "Build Windows images"
+    runs-on: windows-2019
+    permissions:
+      contents: read
+      packages: write
+    env:
+      # Turned on by default in .env but Windows does not support Buildkite
+      # BUILDKIT_INLINE_CACHE: 1
+      DOCKER_BUILDKIT: 0
+      # archery uses this environment variable
+      PYTHON: "3.10"
+      # this is a private repository at the moment (mostly because of licensing
+      # consideration of windows images with visual studio), but anyone can
+      # recreate the image by manually building it via:
+      # `archery build python-wheel-windows-vs2017`
+      # note that we don't run docker build since there wouldn't be a cache hit
+      # and rebuilding the dependencies takes a fair amount of time
+      REPO: ghcr.io/ursacomputing/arrow
+
+    steps:
+      - name: Checkout Arrow
+        uses: actions/checkout@v2
+        with:
+          repository: ${{ github.event.inputs.arrow-repo || 'apache/arrow'}}
+          path: arrow
+          ref: ${{ github.event.inputs.arrow-ref || 'master'}}
+
+      - name: Login to GitHub Container Registry
+        shell: bash
+        run: echo ${{secrets.GITHUB_TOKEN }} | docker login ghcr.io -u ${{ github.actor }} --password-stdin
+
+      - name: Set up Python
+        uses: actions/setup-python@v2
+        with:
+          python-version: 3.8
+          
+      - name: Install Archery
+        shell: bash
+        run: pip install -e arrow/dev/archery[all]
+
+      - name: Retrieve VCPKG version from arrow/.env
+        shell: bash
+        run: |
+          if [ -z "${{ github.event.inputs.vcpkg-version }}" ]; then
+            vcpkg_version=$(cat "arrow/.env" | grep "VCPKG" | cut -d "=" -f2 | tr -d '"')
+          else
+            vcpkg_version="${{ github.event.inputs.vcpkg-version }}"
+          fi
+          echo "VCPKG=$vcpkg_version" >> $GITHUB_ENV
+
+      - name: Build image
+        shell: cmd
+        run: |
+          set PYTHON=3.7&& archery docker build --no-pull python-wheel-windows-vs2017
+          set PYTHON=3.8&& archery docker build --no-pull python-wheel-windows-vs2017
+          set PYTHON=3.9&& archery docker build --no-pull python-wheel-windows-vs2017
+          set PYTHON=3.10&& archery docker build --no-pull python-wheel-windows-vs2017
+
+      - name: Push Image
+        shell: cmd
+        run: |
+          set PYTHON=3.7&& archery docker push python-wheel-windows-vs2017
+          set PYTHON=3.8&& archery docker push python-wheel-windows-vs2017
+          set PYTHON=3.9&& archery docker push python-wheel-windows-vs2017
+          set PYTHON=3.10&& archery docker push python-wheel-windows-vs2017

--- a/.github/workflows/windows_docker.yml
+++ b/.github/workflows/windows_docker.yml
@@ -56,15 +56,11 @@ jobs:
         shell: bash
         run: pip install -e arrow/dev/archery[all]
 
-      - name: Retrieve VCPKG version from arrow/.env
+      - name: Set custom VCPKG version
+        if: github.event.inputs.vcpkg-version != ''
         shell: bash
         run: |
-          if [ -z "${{ github.event.inputs.vcpkg-version }}" ]; then
-            vcpkg_version=$(cat "arrow/.env" | grep "VCPKG" | cut -d "=" -f2 | tr -d '"')
-          else
-            vcpkg_version="${{ github.event.inputs.vcpkg-version }}"
-          fi
-          echo "VCPKG=$vcpkg_version" >> $GITHUB_ENV
+          echo "VCPKG=${{ github.event.inputs.vcpkg-version }}" >> $GITHUB_ENV
 
       - name: Build image
         shell: cmd

--- a/.github/workflows/windows_docker.yml
+++ b/.github/workflows/windows_docker.yml
@@ -22,7 +22,7 @@ jobs:
       contents: read
       packages: write
     env:
-      # Turned on by default in .env but Windows does not support Buildkite
+      # Turned on by default in .env but Windows does not support buildkit
       # BUILDKIT_INLINE_CACHE: 1
       DOCKER_BUILDKIT: 0
       # archery uses this environment variable


### PR DESCRIPTION
This version is not caching between runs but enables us to rebuilt the base images, e.g. for PRs.
