### PR TITLE
Generate and store csv reports

### DIFF
--- a/.github/workflows/report.yml
+++ b/.github/workflows/report.yml
@@ -21,7 +21,7 @@ on:
 jobs:
 
   nightly-report:
-    name: Send nightly ${{ inputs.report_type }} report
+    name: Send and build nightly ${{ inputs.report_type }} report
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Arrow
@@ -66,3 +66,12 @@ jobs:
             --no-fetch \
             --webhook ${{ secrets.CROSSBOW_ZULIP_WEBHOOK }} \
             ${job_id}
+          echo "Generating ${job_id} CSV ..."
+          cd crossbow/csv_reports
+          archery crossbow report-csv \
+            --save \
+            --no-fetch \
+            ${job_id}
+      - uses: stefanzweifel/git-auto-commit-action@v4
+        with:
+          commit_message: Auto commit ${job_id} csv

--- a/.github/workflows/report.yml
+++ b/.github/workflows/report.yml
@@ -28,8 +28,10 @@ jobs:
         shell: bash
         run: git clone https://github.com/apache/arrow
       - name: Checkout Crossbow
-        shell: bash
-        run: git clone https://github.com/ursacomputing/crossbow
+        uses: actions/checkout@v3
+        with:
+          path: crossbow
+          fetch-depth: 0
       - uses: actions/setup-python@v2
         with:
           python-version: '3.8'
@@ -72,6 +74,9 @@ jobs:
             --save \
             --no-fetch \
             ${job_id}
-      - uses: stefanzweifel/git-auto-commit-action@v4
+      - name: Commit CSV report
+        uses: stefanzweifel/git-auto-commit-action@v4
         with:
-          commit_message: Auto commit ${job_id} csv
+          commit_message: Auto commit nightly-${{ inputs.report_type }} CSV
+          repository: crossbow
+          file_pattern: csv_reports/*.csv

--- a/.github/workflows/report.yml
+++ b/.github/workflows/report.yml
@@ -75,8 +75,15 @@ jobs:
             --no-fetch \
             ${job_id}
       - name: Commit CSV report
-        uses: stefanzweifel/git-auto-commit-action@v4
-        with:
-          commit_message: Auto commit nightly-${{ inputs.report_type }} CSV
-          repository: crossbow
-          file_pattern: csv_reports/*.csv
+        shell: bash
+        run: |
+          job_prefix=nightly-${{ inputs.report_type }}-$(date -I)
+          cd crossbow
+          echo "Adding file to repo"
+          git add csv_reports/*.csv
+          echo "Commit CSV"
+          git -c user.name="github-actions[bot]" -c user.email="github-actions[bot]@users.noreply.github.com" \
+            commit -m "Auto commit ${job_prefix} CSV" \
+            --author="${{ github.actor }} <${{ github.actor }}@users.noreply.github.com>"
+          echo "Pushing to repo"
+          git push origin

--- a/.github/workflows/report.yml
+++ b/.github/workflows/report.yml
@@ -83,7 +83,6 @@ jobs:
           git add csv_reports/*.csv
           echo "Commit CSV"
           git -c user.name="github-actions[bot]" -c user.email="github-actions[bot]@users.noreply.github.com" \
-            commit -m "Auto commit ${job_prefix} CSV" \
-            --author="${{ github.actor }} <${{ github.actor }}@users.noreply.github.com>"
+            commit -m "Auto commit ${job_prefix} CSV"
           echo "Pushing to repo"
           git push origin

--- a/csv_reports/README.md
+++ b/csv_reports/README.md
@@ -1,0 +1,3 @@
+# Nightly CSV reports
+
+Nightly report CSVs are stored on this folder.


### PR DESCRIPTION
This change will add a couple of new steps to the Nightly reports.
It will generate a CSV file with the report and it will automatically commit it and store it to the csv_reports folder.

An example of execution of this new workflow can be seen on my fork.
This is an example of the execution, bear in mind I had to do some minor modifications to make it work on my fork:
https://github.com/raulcd/crossbow/runs/6575792648?check_suite_focus=true
And the generated commit can be seen here:
https://github.com/raulcd/crossbow/commit/a6eed0d1c2d7f04a9c14a38606bbbac949e5cf41
