### PR TITLE
Manual Triggers

### DIFF
--- a/.github/workflows/nightly_packaging_report.yml
+++ b/.github/workflows/nightly_packaging_report.yml
@@ -1,6 +1,12 @@
 name: Report packaging
 
 on:
+  workflow_dispatch:
+    inputs:
+      date:
+        description: 'ISO date string to use in the action.'
+        required: false
+        default: ''
   push:
     paths:
       - '.github/workflows/nightly_packaging_report.yml'
@@ -12,6 +18,7 @@ jobs:
     uses: ursacomputing/crossbow/.github/workflows/report.yml@master
     with:
       report_type: packaging
+      date: '${{ inputs.date }}'
     secrets:
       CROSSBOW_GITHUB_TOKEN: ${{ secrets.CROSSBOW_GITHUB_TOKEN }}
       CROSSBOW_SMTP_USER: ${{ secrets.CROSSBOW_SMTP_USER }}

--- a/.github/workflows/nightly_packaging_report.yml
+++ b/.github/workflows/nightly_packaging_report.yml
@@ -4,7 +4,7 @@ on:
   workflow_dispatch:
     inputs:
       date:
-        description: 'ISO date string to use in the action.'
+        description: 'ISO date string to use in the action. Format YYYY-MM-DD'
         required: false
         default: ''
 

--- a/.github/workflows/nightly_packaging_report.yml
+++ b/.github/workflows/nightly_packaging_report.yml
@@ -7,9 +7,7 @@ on:
         description: 'ISO date string to use in the action.'
         required: false
         default: ''
-  push:
-    paths:
-      - '.github/workflows/nightly_packaging_report.yml'
+
   schedule:
     - cron: '0 14 * * *'
 

--- a/.github/workflows/nightly_packaging_submit.yml
+++ b/.github/workflows/nightly_packaging_submit.yml
@@ -4,7 +4,7 @@ on:
   workflow_dispatch:
     inputs:
       date:
-        description: 'ISO date string to use in the action.'
+        description: 'ISO date string to use in the action. Format YYYY-MM-DD'
         required: false
         default: ''
 

--- a/.github/workflows/nightly_packaging_submit.yml
+++ b/.github/workflows/nightly_packaging_submit.yml
@@ -13,7 +13,7 @@ on:
 
 jobs:
   nightly_packaging_submit:
-    uses: ursacomputing/crossbow/.github/workflows/submit.yml@master
+    uses: ursacomputing/crossbow/.github/workflows/submit.yml@manual-reports
     with:
       report_type: packaging
       date: '${{ inputs.date }}'

--- a/.github/workflows/nightly_packaging_submit.yml
+++ b/.github/workflows/nightly_packaging_submit.yml
@@ -13,7 +13,7 @@ on:
 
 jobs:
   nightly_packaging_submit:
-    uses: ursacomputing/crossbow/.github/workflows/submit.yml@manual-reports
+    uses: ursacomputing/crossbow/.github/workflows/submit.yml@master
     with:
       report_type: packaging
       date: '${{ inputs.date }}'

--- a/.github/workflows/nightly_packaging_submit.yml
+++ b/.github/workflows/nightly_packaging_submit.yml
@@ -7,9 +7,7 @@ on:
         description: 'ISO date string to use in the action.'
         required: false
         default: ''
-  push:
-    paths:
-      - '.github/workflows/nightly_packaging_submit.yml'
+
   schedule:
     - cron: '0 8 * * *'
 

--- a/.github/workflows/nightly_packaging_submit.yml
+++ b/.github/workflows/nightly_packaging_submit.yml
@@ -1,6 +1,12 @@
 name: Submit packaging
 
 on:
+  workflow_dispatch:
+    inputs:
+      date:
+        description: 'ISO date string to use in the action.'
+        required: false
+        default: ''
   push:
     paths:
       - '.github/workflows/nightly_packaging_submit.yml'
@@ -12,5 +18,6 @@ jobs:
     uses: ursacomputing/crossbow/.github/workflows/submit.yml@master
     with:
       report_type: packaging
+      date: '${{ inputs.date }}'
     secrets:
       CROSSBOW_GITHUB_TOKEN: ${{ secrets.CROSSBOW_GITHUB_TOKEN }}

--- a/.github/workflows/nightly_release_report.yml
+++ b/.github/workflows/nightly_release_report.yml
@@ -4,7 +4,7 @@ on:
   workflow_dispatch:
     inputs:
       date:
-        description: 'ISO date string to use in the action.'
+        description: 'ISO date string to use in the action. Format YYYY-MM-DD'
         required: false
         default: ''
 

--- a/.github/workflows/nightly_release_report.yml
+++ b/.github/workflows/nightly_release_report.yml
@@ -1,6 +1,12 @@
 name: Report release
 
 on:
+  workflow_dispatch:
+    inputs:
+      date:
+        description: 'ISO date string to use in the action.'
+        required: false
+        default: ''
   push:
     paths:
       - '.github/workflows/nightly_release_report.yml'
@@ -12,6 +18,7 @@ jobs:
     uses: ursacomputing/crossbow/.github/workflows/report.yml@master
     with:
       report_type: release
+      date: '${{ inputs.date }}'
     secrets:
       CROSSBOW_GITHUB_TOKEN: ${{ secrets.CROSSBOW_GITHUB_TOKEN }}
       CROSSBOW_SMTP_USER: ${{ secrets.CROSSBOW_SMTP_USER }}

--- a/.github/workflows/nightly_release_report.yml
+++ b/.github/workflows/nightly_release_report.yml
@@ -7,9 +7,7 @@ on:
         description: 'ISO date string to use in the action.'
         required: false
         default: ''
-  push:
-    paths:
-      - '.github/workflows/nightly_release_report.yml'
+
   schedule:
     - cron: '0 20 * * *'
 

--- a/.github/workflows/nightly_release_submit.yml
+++ b/.github/workflows/nightly_release_submit.yml
@@ -4,7 +4,7 @@ on:
   workflow_dispatch:
     inputs:
       date:
-        description: 'ISO date string to use in the action.'
+        description: 'ISO date string to use in the action. Format YYYY-MM-DD'
         required: false
         default: ''
 

--- a/.github/workflows/nightly_release_submit.yml
+++ b/.github/workflows/nightly_release_submit.yml
@@ -7,9 +7,7 @@ on:
         description: 'ISO date string to use in the action.'
         required: false
         default: ''
-  push:
-    paths:
-      - '.github/workflows/nightly_release_submit.yml'
+
   schedule:
     - cron: '0 14 * * *'
 

--- a/.github/workflows/nightly_release_submit.yml
+++ b/.github/workflows/nightly_release_submit.yml
@@ -1,6 +1,12 @@
 name: Submit release
 
 on:
+  workflow_dispatch:
+    inputs:
+      date:
+        description: 'ISO date string to use in the action.'
+        required: false
+        default: ''
   push:
     paths:
       - '.github/workflows/nightly_release_submit.yml'
@@ -12,5 +18,6 @@ jobs:
     uses: ursacomputing/crossbow/.github/workflows/submit.yml@master
     with:
       report_type: release
+      date: '${{ inputs.date }}'
     secrets:
       CROSSBOW_GITHUB_TOKEN: ${{ secrets.CROSSBOW_GITHUB_TOKEN }}

--- a/.github/workflows/nightly_tests_report.yml
+++ b/.github/workflows/nightly_tests_report.yml
@@ -4,7 +4,7 @@ on:
   workflow_dispatch:
     inputs:
       date:
-        description: 'ISO date string to use in the action.'
+        description: 'ISO date string to use in the action. Format YYYY-MM-DD'
         required: false
         default: ''
 

--- a/.github/workflows/nightly_tests_report.yml
+++ b/.github/workflows/nightly_tests_report.yml
@@ -7,9 +7,7 @@ on:
         description: 'ISO date string to use in the action.'
         required: false
         default: ''
-  push:
-    paths:
-      - '.github/workflows/nightly_tests_report.yml'
+
   schedule:
     - cron: '0 8 * * *'
 

--- a/.github/workflows/nightly_tests_report.yml
+++ b/.github/workflows/nightly_tests_report.yml
@@ -1,6 +1,12 @@
 name: Report tests
 
 on:
+  workflow_dispatch:
+    inputs:
+      date:
+        description: 'ISO date string to use in the action.'
+        required: false
+        default: ''
   push:
     paths:
       - '.github/workflows/nightly_tests_report.yml'
@@ -12,6 +18,7 @@ jobs:
     uses: ursacomputing/crossbow/.github/workflows/report.yml@master
     with:
       report_type: tests
+      date: '${{ inputs.date }}'
     secrets:
       CROSSBOW_GITHUB_TOKEN: ${{ secrets.CROSSBOW_GITHUB_TOKEN }}
       CROSSBOW_SMTP_USER: ${{ secrets.CROSSBOW_SMTP_USER }}

--- a/.github/workflows/nightly_tests_submit.yml
+++ b/.github/workflows/nightly_tests_submit.yml
@@ -4,7 +4,7 @@ on:
   workflow_dispatch:
     inputs:
       date:
-        description: 'ISO date string to use in the action.'
+        description: 'ISO date string to use in the action. Format YYYY-MM-DD'
         required: false
         default: ''
 

--- a/.github/workflows/nightly_tests_submit.yml
+++ b/.github/workflows/nightly_tests_submit.yml
@@ -7,9 +7,7 @@ on:
         description: 'ISO date string to use in the action.'
         required: false
         default: ''
-  push:
-    paths:
-      - '.github/workflows/nightly_tests_submit.yml'
+
   schedule:
     - cron: '0 2 * * *'
 

--- a/.github/workflows/nightly_tests_submit.yml
+++ b/.github/workflows/nightly_tests_submit.yml
@@ -1,6 +1,12 @@
 name: Submit tests
 
 on:
+  workflow_dispatch:
+    inputs:
+      date:
+        description: 'ISO date string to use in the action.'
+        required: false
+        default: ''
   push:
     paths:
       - '.github/workflows/nightly_tests_submit.yml'
@@ -12,5 +18,6 @@ jobs:
     uses: ursacomputing/crossbow/.github/workflows/submit.yml@master
     with:
       report_type: tests
+      date: '${{ inputs.date }}'
     secrets:
       CROSSBOW_GITHUB_TOKEN: ${{ secrets.CROSSBOW_GITHUB_TOKEN }}

--- a/.github/workflows/report.yml
+++ b/.github/workflows/report.yml
@@ -6,6 +6,10 @@ on:
       report_type:
         required: true
         type: string
+      date:
+        required: false
+        default: ''
+        type: string
     secrets:
       CROSSBOW_GITHUB_TOKEN:
         required: true
@@ -38,12 +42,22 @@ jobs:
       - name: Install Archery
         shell: bash
         run: pip install -e arrow/dev/archery[crossbow]
+      - name: Get Date
+        id: date
+        shell: bash
+        env:
+          DATE: ${{ inputs.date }}
+        run: |
+          if [ -z $DATE ]; then
+            DATE=$(date -I)
+          fi
+          echo "::set-output name=date::$DATE"
       - name: Send Report
         shell: bash
         env:
           CROSSBOW_GITHUB_TOKEN: ${{ secrets.CROSSBOW_GITHUB_TOKEN }}
         run: |
-          job_prefix=nightly-${{ inputs.report_type }}-$(date -I)
+          job_prefix=nightly-${{ inputs.report_type }}-${{ steps.date.outputs.date }}
           job_id=$(archery crossbow latest-prefix ${job_prefix})
           echo "Sending report for job ${job_id}..."
           archery crossbow report \
@@ -77,7 +91,7 @@ jobs:
       - name: Commit CSV report
         shell: bash
         run: |
-          job_prefix=nightly-${{ inputs.report_type }}-$(date -I)
+          job_prefix=nightly-${{ inputs.report_type }}-${{ steps.date.outputs.date }}
           cd crossbow
           echo "Adding file to repo"
           git add csv_reports/*.csv

--- a/.github/workflows/submit.yml
+++ b/.github/workflows/submit.yml
@@ -6,6 +6,10 @@ on:
       report_type:
         required: true
         type: string
+      date:
+        required: false
+        default: ''
+        type: string  
     secrets:
       CROSSBOW_GITHUB_TOKEN:
         required: true
@@ -28,8 +32,18 @@ jobs:
       - name: Install Archery
         shell: bash
         run: pip install -e arrow/dev/archery[crossbow]
+      - name: Get Date
+        id: date
+        shell: bash
+        env:
+          DATE: ${{ inputs.date }}
+        run: |
+          if [ -z $DATE ]; then
+            DATE=$(date -I)
+          fi
+          echo "::set-output name=date::$DATE"
       - name: Submit Nightlies
         shell: bash
         env:
           CROSSBOW_GITHUB_TOKEN: ${{ secrets.CROSSBOW_GITHUB_TOKEN }}
-        run: archery crossbow submit --job-prefix nightly-${{ inputs.report_type }}-$(date -I) --group nightly-${{ inputs.report_type }}
+        run: archery crossbow submit --job-prefix nightly-${{ inputs.report_type }}-${{ steps.date.outputs.date }} --group nightly-${{ inputs.report_type }}


### PR DESCRIPTION
This PR adds manual triggers for the packaging and report workflows. They can now be started with a custom ISO date string (e.g. to re-run failed jobs from a specific day) , this will only be active once this is merged to master.
I also removed the `on.push` triggers as they are superfluous with manual triggers imho and could lead to unwanted triggering of the workflows.