### PR TITLE
make defensive against missing column

### DIFF
--- a/crossbow-nightly-report.Rmd
+++ b/crossbow-nightly-report.Rmd
@@ -202,7 +202,7 @@ for (.x in unique(build_table$build_type)) {
   ## Need to sort columns at this level because of variable fail dates
   ## TODO: find something a little less hacky
   bs_nightly_tbl <- bs_nightly_tbl[, rev(sort(names(bs_nightly_tbl)))] %>%
-    relocate(most_recent_failure, .after = last_col()) %>%
+    relocate(any_of("most_recent_failure"), .after = last_col()) %>%
     relocate(any_of(c("last_successful_build", "first_failure")), .after = last_successful_commit)
 
   names(bs_nightly_tbl) <- make_nice_names(bs_nightly_tbl)


### PR DESCRIPTION
Fixes: https://github.com/ursacomputing/crossbow/runs/6991188310?check_suite_focus=true#step:6:875

This PR deals with instances where "First Failure" is the same as "Most Recent Failures" for all builds. In those cases, we just drop the "Most Recent Failures" as that would be confusing. 