### PR TITLE
remove r-nightly-packages from build table

### DIFF
--- a/crossbow-nightly-report.Rmd
+++ b/crossbow-nightly-report.Rmd
@@ -185,7 +185,7 @@ nightly %>%
 ```{r results="asis"}
 map_params <- nightly %>%
   distinct(task_name, build_type) %>% 
-  filter(!task_name %in% c("r-nightly-packages")) # tasks that are no with us
+  filter(!task_name %in% c("r-nightly-packages", "test-r-rstudio-r-base-4.2-opensuse42")) # tasks that are no longer active
 
 build_table <- map2_df(map_params$build_type, map_params$task_name, ~ arrow_build_table(nightly, type = .x, task = .y))
 

--- a/crossbow-nightly-report.Rmd
+++ b/crossbow-nightly-report.Rmd
@@ -184,7 +184,8 @@ nightly %>%
 
 ```{r results="asis"}
 map_params <- nightly %>%
-  distinct(task_name, build_type)
+  distinct(task_name, build_type) %>% 
+  filter(!task_name %in% c("r-nightly-packages")) # tasks that are no with us
 
 build_table <- map2_df(map_params$build_type, map_params$task_name, ~ arrow_build_table(nightly, type = .x, task = .y))
 


### PR DESCRIPTION
Removed `r-nightly-packages` from build table. I have kept it in the Error Logs because that history could conceivably be useful.