### PR TITLE
Update mailing list to notify Token expiration

### DIFF
--- a/.github/workflows/token_expiration.yml
+++ b/.github/workflows/token_expiration.yml
@@ -44,7 +44,7 @@ jobs:
             --send \
             --sender-name Crossbow \
             --sender-email 'crossbow@ursalabs.org' \
-            --recipient-email 'raulcd@apache.org' \
+            --recipient-email 'dev@arrow.apache.org' \
             --smtp-user ${{ secrets.CROSSBOW_SMTP_USER }} \
             --smtp-password ${{ secrets.CROSSBOW_SMTP_PASSWORD }} \
             --days ${{ inputs.days }}

--- a/.github/workflows/token_expiration.yml
+++ b/.github/workflows/token_expiration.yml
@@ -44,7 +44,7 @@ jobs:
             --send \
             --sender-name Crossbow \
             --sender-email 'crossbow@ursalabs.org' \
-            --recipient-email 'dev@arrow.apache.org' \
+            --recipient-email 'builds@arrow.apache.org' \
             --smtp-user ${{ secrets.CROSSBOW_SMTP_USER }} \
             --smtp-password ${{ secrets.CROSSBOW_SMTP_PASSWORD }} \
             --days ${{ inputs.days }}


### PR DESCRIPTION
I have tested this works correctly.
Example of run with 30 days: https://github.com/ursacomputing/crossbow/actions/runs/3712568591/jobs/6294245544#step:6:23
Example of run with 365 days: https://github.com/ursacomputing/crossbow/actions/runs/3712588042/jobs/6294285801

I did receive the following email on my email:
```
De: Crossbow <[crossbow@ursalabs.org](mailto:crossbow@ursalabs.org)>
Date: vie, 16 dic 2022 a las 12:12
Subject: [CI] Arrow Crossbow Token Expiration in 2023-12-13
To: <[raulcd@apache.org](mailto:raulcd@apache.org)>


The Arrow Crossbow Token will expire in 362 days.

Please generate a new Token. Send it to Apache INFRA to update the CROSSBOW_GITHUB_TOKEN.
Update it on the crossbow repository and in the Azure pipelines.
```