### PR TITLE
Fix failure on token-expiration scheduled trigger missing days

### DIFF
--- a/.github/workflows/token_expiration.yml
+++ b/.github/workflows/token_expiration.yml
@@ -47,4 +47,4 @@ jobs:
             --recipient-email 'builds@arrow.apache.org' \
             --smtp-user ${{ secrets.CROSSBOW_SMTP_USER }} \
             --smtp-password ${{ secrets.CROSSBOW_SMTP_PASSWORD }} \
-            --days ${{ inputs.days }}
+            --days ${{ inputs.days || '30'}}


### PR DESCRIPTION
This fixes the following error: https://github.com/ursacomputing/crossbow/actions/runs/3727190422/jobs/6321109276