### PR TITLE
Only show active jobs in the build status

### DIFF
--- a/.github/workflows/nightly_dashboard.yml
+++ b/.github/workflows/nightly_dashboard.yml
@@ -6,6 +6,7 @@ concurrency:
 
 on:
   workflow_dispatch:
+  pull_request:
   push:
     branches: [master, main]
     paths:
@@ -52,7 +53,14 @@ jobs:
         shell: Rscript {0}
         run: |
           rmarkdown::render("crossbow-nightly-report.Rmd", output_file = "index.html")
+      - name: Upload Rendered Dashboard
+        if: github.event_name == 'pull_request'
+        uses: actions/upload-artifact@v3
+        with:
+          name: dashboard
+          path: crossbow/index.html
       - name: Upload result
+        if: github.event_name == 'push'
         working-directory: crossbow
         shell: bash
         env:

--- a/.github/workflows/nightly_dashboard.yml
+++ b/.github/workflows/nightly_dashboard.yml
@@ -23,6 +23,11 @@ jobs:
         run: |
           git clone https://github.com/apache/arrow
           git clone https://github.com/ursacomputing/crossbow
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          cache: pip
+          python-version: 3.11
       - name: Generate List of Crossbow Tasks
         run: |
           python -m pip install -e arrow/dev/archery[crossbow]

--- a/.github/workflows/nightly_dashboard.yml
+++ b/.github/workflows/nightly_dashboard.yml
@@ -18,7 +18,14 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
 
-      - uses: actions/checkout@v3
+      - name: Checkout Arrow & Crossbow
+        run: |
+          git clone https://github.com/apache/arrow
+          git clone https://github.com/ursacomputing/crossbow
+      - name: Generate List of Crossbow Tasks
+        run: |
+          python -m pip install -e arrow/dev/archery[crossbow]
+          archery crossbow check-config > crossbow/all.yml
       - uses: r-lib/actions/setup-r@v2
         with:
           use-public-rspm: true
@@ -39,11 +46,14 @@ jobs:
             any::cli
             any::lubridate
             any::tibble
+            any::yaml
       - name: Build Report
+        working-directory: crossbow
         shell: Rscript {0}
         run: |
           rmarkdown::render("crossbow-nightly-report.Rmd", output_file = "index.html")
       - name: Upload result
+        working-directory: crossbow
         shell: bash
         env:
           AWS_ACCESS_KEY_ID: ${{ secrets.CROSSBOW_DOCS_AWS_ACCESS_KEY_ID }}

--- a/.github/workflows/nightly_dashboard.yml
+++ b/.github/workflows/nightly_dashboard.yml
@@ -32,6 +32,7 @@ jobs:
         run: |
           python -m pip install -e arrow/dev/archery[crossbow]
           archery crossbow check-config > crossbow/all.yml
+      - run: cat crossbow/all.yml
       - uses: r-lib/actions/setup-r@v2
         with:
           use-public-rspm: true

--- a/.github/workflows/nightly_dashboard.yml
+++ b/.github/workflows/nightly_dashboard.yml
@@ -19,10 +19,13 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
 
-      - name: Checkout Arrow & Crossbow
-        run: |
-          git clone https://github.com/apache/arrow
-          git clone https://github.com/ursacomputing/crossbow
+      - uses: actions/checkout@v3
+        with:
+          repository: apache/arrow
+          path: arrow
+      - uses: actions/checkout@v3
+        with:
+          path: crossbow
       - name: Set up Python
         uses: actions/setup-python@v4
         with:
@@ -32,7 +35,6 @@ jobs:
         run: |
           python -m pip install -e arrow/dev/archery[crossbow]
           archery crossbow check-config > crossbow/all.yml
-      - run: cat crossbow/all.yml
       - uses: r-lib/actions/setup-r@v2
         with:
           use-public-rspm: true

--- a/.github/workflows/nightly_dashboard.yml
+++ b/.github/workflows/nightly_dashboard.yml
@@ -66,7 +66,9 @@ jobs:
         uses: actions/upload-artifact@v3
         with:
           name: dashboard
-          path: crossbow/index.html
+          path: |
+            crossbow/index.html
+            crossbow/all.yml
       - name: Upload result
         if: github.event_name == 'push'
         working-directory: crossbow

--- a/crossbow-nightly-report.Rmd
+++ b/crossbow-nightly-report.Rmd
@@ -234,11 +234,11 @@ packaging <- tasks$groups[["nightly-packaging"]]
 release <- tasks$groups[["nightly-release"]]
 nightly_regex <-  paste0(c(tests, packaging, release), collapse = "|")
 
-active_jobs <- tasks$tasks |> names() %>% grep(nightly_regex, x = ., value = TRUE)
+active_jobs <- tasks$tasks %>% names() %>% grep(nightly_regex, x = ., value = TRUE)
 
 map_params <- nightly %>%
   distinct(task_name, build_type) %>%
-  filter(task_name %in% active_jobs) 
+  filter(task_name %in% active_jobs)
 
 build_table <- map2_df(map_params$build_type, map_params$task_name, ~ arrow_build_table(nightly, type = .x, task = .y))
 

--- a/crossbow-nightly-report.Rmd
+++ b/crossbow-nightly-report.Rmd
@@ -23,6 +23,7 @@ library(cli)
 library(tools)
 library(tibble)
 library(lubridate)
+library(yaml)
 
 
 crossbow_theme <- function(data, ...) {
@@ -225,9 +226,19 @@ pass_pct %>%
 # Build Status  {.tabset}
 
 ```{r results="asis"}
+# this file can be generated with `archery crossbow check-config > all.yml`
+tasks <- yaml.load_file("all.yml")
+
+tests <- tasks$groups[["nightly-tests"]]
+packaging <- tasks$groups[["nightly-packaging"]]
+release <- tasks$groups[["nightly-release"]]
+nightly_regex <-  paste0(c(tests, packaging, release), collapse = "|")
+
+active_jobs <- tasks$tasks |> names() %>% grep(nightly_regex, x = ., value = TRUE)
+
 map_params <- nightly %>%
   distinct(task_name, build_type) %>%
-  filter(!task_name %in% c("r-nightly-packages", "test-r-rstudio-r-base-4.2-opensuse42")) # tasks that are no longer active
+  filter(task_name %in% active_jobs) 
 
 build_table <- map2_df(map_params$build_type, map_params$task_name, ~ arrow_build_table(nightly, type = .x, task = .y))
 


### PR DESCRIPTION
As discussed on zulip we want to have a more future proof version than manually adding job names to filter out.