### PR TITLE
Fix workflows after default branch rename

### DIFF
--- a/.github/workflows/cache_vcpkg.yml
+++ b/.github/workflows/cache_vcpkg.yml
@@ -31,7 +31,7 @@ on:
       arrow-ref:
         description: 'Ref to checkout from arrow-repo.'
         required: true
-        default: 'master'
+        default: 'main'
   # perhaps daily one for keeping the cache warm
   push:
     paths:
@@ -64,7 +64,7 @@ jobs:
         with:
           repository: ${{ github.event.inputs.arrow-repo || 'apache/arrow'}}
           path: arrow
-          ref: ${{ github.event.inputs.arrow-ref || 'master'}}
+          ref: ${{ github.event.inputs.arrow-ref || 'main'}}
       - name: Retrieve VCPKG version from arrow/.env
         shell: bash
         run: |

--- a/.github/workflows/nightly_dashboard.yml
+++ b/.github/workflows/nightly_dashboard.yml
@@ -8,7 +8,7 @@ on:
   workflow_dispatch:
   pull_request:
   push:
-    branches: [master, main]
+    branches: main
     paths:
       - "csv_reports/*.csv"
       - ".github/workflows/nightly_dashboard.yml"

--- a/.github/workflows/nightly_packaging_report.yml
+++ b/.github/workflows/nightly_packaging_report.yml
@@ -13,7 +13,7 @@ on:
 
 jobs:
   nightly_packaging_report:
-    uses: ursacomputing/crossbow/.github/workflows/report.yml@master
+    uses: ursacomputing/crossbow/.github/workflows/report.yml@main
     with:
       report_type: packaging
       date: '${{ inputs.date }}'

--- a/.github/workflows/nightly_packaging_submit.yml
+++ b/.github/workflows/nightly_packaging_submit.yml
@@ -13,7 +13,7 @@ on:
 
 jobs:
   nightly_packaging_submit:
-    uses: ursacomputing/crossbow/.github/workflows/submit.yml@master
+    uses: ursacomputing/crossbow/.github/workflows/submit.yml@main
     with:
       report_type: packaging
       date: '${{ inputs.date }}'

--- a/.github/workflows/nightly_release_report.yml
+++ b/.github/workflows/nightly_release_report.yml
@@ -13,7 +13,7 @@ on:
 
 jobs:
   nightly_release_report:
-    uses: ursacomputing/crossbow/.github/workflows/report.yml@master
+    uses: ursacomputing/crossbow/.github/workflows/report.yml@main
     with:
       report_type: release
       date: '${{ inputs.date }}'

--- a/.github/workflows/nightly_release_submit.yml
+++ b/.github/workflows/nightly_release_submit.yml
@@ -13,7 +13,7 @@ on:
 
 jobs:
   nightly_release_submit:
-    uses: ursacomputing/crossbow/.github/workflows/submit.yml@master
+    uses: ursacomputing/crossbow/.github/workflows/submit.yml@main
     with:
       report_type: release
       date: '${{ inputs.date }}'

--- a/.github/workflows/nightly_tests_report.yml
+++ b/.github/workflows/nightly_tests_report.yml
@@ -13,7 +13,7 @@ on:
 
 jobs:
   nightly_tests_report:
-    uses: ursacomputing/crossbow/.github/workflows/report.yml@master
+    uses: ursacomputing/crossbow/.github/workflows/report.yml@main
     with:
       report_type: tests
       date: '${{ inputs.date }}'

--- a/.github/workflows/nightly_tests_submit.yml
+++ b/.github/workflows/nightly_tests_submit.yml
@@ -13,7 +13,7 @@ on:
 
 jobs:
   nightly_tests_submit:
-    uses: ursacomputing/crossbow/.github/workflows/submit.yml@master
+    uses: ursacomputing/crossbow/.github/workflows/submit.yml@main
     with:
       report_type: tests
       date: '${{ inputs.date }}'

--- a/.github/workflows/windows_docker.yml
+++ b/.github/workflows/windows_docker.yml
@@ -12,7 +12,7 @@ on:
      arrow-ref:
        description: 'Ref to checkout from arrow-repo.'
        required: true
-       default: 'master'
+       default: 'main'
 
 jobs:
   build:
@@ -41,7 +41,7 @@ jobs:
         with:
           repository: ${{ github.event.inputs.arrow-repo || 'apache/arrow'}}
           path: arrow
-          ref: ${{ github.event.inputs.arrow-ref || 'master'}}
+          ref: ${{ github.event.inputs.arrow-ref || 'main'}}
 
       - name: Login to GitHub Container Registry
         shell: bash

--- a/README.md
+++ b/README.md
@@ -6,4 +6,4 @@ The nightly builds are submitted by cron jobs running as Github Actions
 cron jobs, see the github actions workflows defined in this repository.
 
 For the triggered tasks see the nightly group of crossbow's
-[task definition file](https://github.com/apache/arrow/blob/master/dev/tasks/tasks.yml).
+[task definition file](https://github.com/apache/arrow/blob/main/dev/tasks/tasks.yml).


### PR DESCRIPTION
Branch tags in workflows are not forwarded apparently, which broke the workflows.