### PR TITLE
Catch possible error when pruning docs-preview and continue cleaning

### DIFF
--- a/.github/workflows/prune_previews.yml
+++ b/.github/workflows/prune_previews.yml
@@ -27,12 +27,18 @@ jobs:
           script: |
             let prs = "${{ env.PRs }}".split(" ").filter(x => x)
             async function not_open(id) {
-             let pr = await github.rest.pulls.get({
-              "owner": "apache",
-              "repo": "arrow",
-              "pull_number": id
-              })
-              
+             try {
+                let pr = await github.rest.pulls.get({
+                "owner": "apache",
+                "repo": "arrow",
+                "pull_number": id
+                })
+              }
+              catch(err) {
+                # In case of error retrieving PR try to clean it.
+                # Example manually triggered job with different naming.
+                return(id)
+              }
               if(pr.data.state !== "open") {
                 return(id)
               }


### PR DESCRIPTION
This should solve the current failure when the name submitted is not the PR id:
https://github.com/ursacomputing/crossbow/actions/runs/5721841496/job/15504023404#step:3:31