### PR TITLE
Performance report

### DIFF
--- a/.github/workflows/performance-release-report.yml
+++ b/.github/workflows/performance-release-report.yml
@@ -23,6 +23,9 @@ on:
         description: 'RC Label'
         required: false
 
+permissions:
+  contents: read
+  
 env: 
     ## payload vars
     BASELINE_GIT_COMMIT: ${{ github.event.inputs.baseline_git_commit }}

--- a/.github/workflows/performance-release-report.yml
+++ b/.github/workflows/performance-release-report.yml
@@ -22,14 +22,12 @@ on:
       rc_label:
         description: 'RC Label'
         required: false
-  repository_dispatch:
-     types: [perf-report]
 
 env: 
     ## payload vars
-    BASELINE_GIT_COMMIT: ${{ github.event.client_payload.baseline_git_commit || github.event.inputs.baseline_git_commit }}
-    CONTENDER_GIT_COMMIT: ${{ github.event.client_payload.contender_git_commit || github.event.inputs.contender_git_commit }}
-    RC_LABEL: ${{ github.event.client_payload.rc_label || github.event.inputs.rc_label || 'manual' }}
+    BASELINE_GIT_COMMIT: ${{ github.event.inputs.baseline_git_commit }}
+    CONTENDER_GIT_COMMIT: ${{ github.event.inputs.contender_git_commit }}
+    RC_LABEL: ${{ github.event.inputs.rc_label || 'manual' }}
 
 jobs:
   build:

--- a/.github/workflows/performance-release-report.yml
+++ b/.github/workflows/performance-release-report.yml
@@ -74,9 +74,9 @@ jobs:
         with:
           name: perf-report
           path: 'performance-release-report/performance-release-report.html'
+
       # - name: Upload result
       #   if: github.event_name == 'push'
-      #   working-directory: crossbow
       #   shell: bash
       #   env:
       #     AWS_ACCESS_KEY_ID: ${{ secrets.CROSSBOW_DOCS_AWS_ACCESS_KEY_ID }}
@@ -84,4 +84,4 @@ jobs:
       #     AWS_DEFAULT_REGION: ${{ secrets.CROSSBOW_DOCS_S3_BUCKET_REGION }}
       #     BUCKET: ${{ secrets.CROSSBOW_DOCS_S3_BUCKET }}
       #   run: |
-      #     aws s3 cp index.html $BUCKET/index.html 
+      #     aws s3 cp index.html $BUCKET/performance-release-report${{ env.RC_LABEL }}.html

--- a/.github/workflows/performance-release-report.yml
+++ b/.github/workflows/performance-release-report.yml
@@ -75,13 +75,14 @@ jobs:
           name: perf-report
           path: 'performance-release-report/performance-release-report.html'
 
-      # - name: Upload result
-      #   if: github.event_name == 'push'
-      #   shell: bash
-      #   env:
-      #     AWS_ACCESS_KEY_ID: ${{ secrets.CROSSBOW_DOCS_AWS_ACCESS_KEY_ID }}
-      #     AWS_SECRET_ACCESS_KEY: ${{ secrets.CROSSBOW_DOCS_AWS_SECRET_ACCESS_KEY }}
-      #     AWS_DEFAULT_REGION: ${{ secrets.CROSSBOW_DOCS_S3_BUCKET_REGION }}
-      #     BUCKET: ${{ secrets.CROSSBOW_DOCS_S3_BUCKET }}
-      #   run: |
-      #     aws s3 cp index.html $BUCKET/performance-release-report${{ env.RC_LABEL }}.html
+      - name: Upload result
+        if: github.event_name == 'push'
+        working-directory: performance-release-report
+        shell: bash
+        env:
+          AWS_ACCESS_KEY_ID: ${{ secrets.CROSSBOW_DOCS_AWS_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.CROSSBOW_DOCS_AWS_SECRET_ACCESS_KEY }}
+          AWS_DEFAULT_REGION: ${{ secrets.CROSSBOW_DOCS_S3_BUCKET_REGION }}
+          BUCKET: ${{ secrets.CROSSBOW_DOCS_S3_BUCKET }}
+        run: |
+          aws s3 cp performance-release-report.html $BUCKET/performance-release-report${{ env.RC_LABEL }}.html

--- a/.github/workflows/performance-release-report.yml
+++ b/.github/workflows/performance-release-report.yml
@@ -70,11 +70,11 @@ jobs:
             to: html
             path: 'performance-release-report/performance-release-report.qmd'
 
-      - name: Upload Rendered Dashboard
+      - name: Upload Rendered Perf Report
         if: github.event_name == 'pull_request'
         uses: actions/upload-artifact@v3
         with:
-          name: dashboard
+          name: perf-report
           path: 'performance-release-report/performance-release-report.html'
       # - name: Upload result
       #   if: github.event_name == 'push'

--- a/.github/workflows/performance-release-report.yml
+++ b/.github/workflows/performance-release-report.yml
@@ -22,6 +22,10 @@ on:
       rc_label:
         description: 'RC Label'
         required: false
+      publish:
+        type: boolean
+        description: 'Publish to S3'
+        required: false
 
 permissions:
   contents: read
@@ -79,7 +83,7 @@ jobs:
           path: 'performance-release-report/performance-release-report.html'
 
       - name: Upload result
-        if: github.event_name == 'push'
+        if: ${{ github.event.inputs.publish == 'true' }}
         working-directory: performance-release-report
         shell: bash
         env:

--- a/.github/workflows/performance-release-report.yml
+++ b/.github/workflows/performance-release-report.yml
@@ -26,6 +26,7 @@ on:
         type: boolean
         description: 'Publish to S3'
         required: false
+        default: false
 
 permissions:
   contents: read

--- a/performance-release-report/performance-release-report.qmd
+++ b/performance-release-report/performance-release-report.qmd
@@ -27,8 +27,6 @@ Sys.unsetenv("CONBENCH_PASSWORD")
 
 baseline_git_commit <- Sys.getenv("BASELINE_GIT_COMMIT") 
 contender_git_commit <-  Sys.getenv("CONTENDER_GIT_COMMIT")
-# baseline_git_commit <- "6af660f48472b8b45a5e01b7136b9b040b185eb1"
-# contender_git_commit <-  "ac2d207611ce25c91fb9fc90d5eaff2933609660"
 hardware_name <- "ursa-i9-9960x"
 
 library(dplyr)
@@ -80,8 +78,6 @@ contender_git_commit_short <- substr(contender_git_commit, 1, 7)
 #| results: 'asis'
 
 runs_raw <- runs(c(baseline_git_commit, contender_git_commit)) 
-
-print(length(runs_raw) == 0)
 
 if (length(runs_raw) == 0) {
   knit_exit("No runs found for the given commits. Please check that the commits are correct and that the benchmark runs have completed.")

--- a/performance-release-report/performance-release-report.qmd
+++ b/performance-release-report/performance-release-report.qmd
@@ -25,10 +25,10 @@ format:
 
 Sys.unsetenv("CONBENCH_PASSWORD")
 
-# baseline_git_commit <- Sys.getenv("BASELINE_GIT_COMMIT") 
-# contender_git_commit <-  Sys.getenv("CONTENDER_GIT_COMMIT")
-baseline_git_commit <- "6af660f48472b8b45a5e01b7136b9b040b185eb1"
-contender_git_commit <-  "ac2d207611ce25c91fb9fc90d5eaff2933609660"
+baseline_git_commit <- Sys.getenv("BASELINE_GIT_COMMIT") 
+contender_git_commit <-  Sys.getenv("CONTENDER_GIT_COMMIT")
+# baseline_git_commit <- "6af660f48472b8b45a5e01b7136b9b040b185eb1"
+# contender_git_commit <-  "ac2d207611ce25c91fb9fc90d5eaff2933609660"
 hardware_name <- "ursa-i9-9960x"
 
 library(dplyr)

--- a/performance-release-report/performance-release-report.qmd
+++ b/performance-release-report/performance-release-report.qmd
@@ -23,8 +23,12 @@ format:
 ```{r setup}
 #| include: false
 
+Sys.unsetenv("CONBENCH_PASSWORD")
+
 baseline_git_commit <- Sys.getenv("BASELINE_GIT_COMMIT") 
 contender_git_commit <-  Sys.getenv("CONTENDER_GIT_COMMIT")
+# baseline_git_commit <- "6af660f48472b8b45a5e01b7136b9b040b185eb1"
+# contender_git_commit <-  "ac2d207611ce25c91fb9fc90d5eaff2933609660"
 hardware_name <- "ursa-i9-9960x"
 
 library(dplyr)
@@ -32,7 +36,6 @@ library(ggplot2)
 library(tidyr)
 library(glue)
 library(purrr)
-library(knitr)
 library(conbenchcoms)
 library(cli)
 library(lubridate)
@@ -62,7 +65,7 @@ theme_set(theme_minimal(base_size = 24, base_family = "roboto") %+replace%
     legend.position = "top"
   ))
   
-knitr::opts_chunk$set(
+opts_chunk$set(
   cache = FALSE,
   echo = FALSE
   )
@@ -78,8 +81,10 @@ contender_git_commit_short <- substr(contender_git_commit, 1, 7)
 
 runs_raw <- runs(c(baseline_git_commit, contender_git_commit)) 
 
+print(length(runs_raw) == 0)
+
 if (length(runs_raw) == 0) {
-  knitr::knit_exit("No runs found for the given commits. Please check that the commits are correct and that the benchmark runs have completed.")
+  knit_exit("No runs found for the given commits. Please check that the commits are correct and that the benchmark runs have completed.")
 } else {
   run_comp <- runs_raw %>%
     filter(hardware.name == hardware_name) %>%
@@ -105,7 +110,7 @@ if (nrow(hardware_summary) != 2) {
   ## fail early and informatively with when not using correct hardware
   missing_commits <- setdiff(c(contender_git_commit, baseline_git_commit), hardware_summary$commit.sha)
   cat(pluralize("Commit{?s} {missing_commits} w{?as/ere} not benchmarked with {hardware_name} hardware. This report only tests that hardware."))
-  knitr::knit_exit()
+  knit_exit()
 }
 ```
 

--- a/performance-release-report/performance-release-report.qmd
+++ b/performance-release-report/performance-release-report.qmd
@@ -25,10 +25,10 @@ format:
 
 Sys.unsetenv("CONBENCH_PASSWORD")
 
-baseline_git_commit <- Sys.getenv("BASELINE_GIT_COMMIT") 
-contender_git_commit <-  Sys.getenv("CONTENDER_GIT_COMMIT")
-# baseline_git_commit <- "6af660f48472b8b45a5e01b7136b9b040b185eb1"
-# contender_git_commit <-  "ac2d207611ce25c91fb9fc90d5eaff2933609660"
+# baseline_git_commit <- Sys.getenv("BASELINE_GIT_COMMIT") 
+# contender_git_commit <-  Sys.getenv("CONTENDER_GIT_COMMIT")
+baseline_git_commit <- "6af660f48472b8b45a5e01b7136b9b040b185eb1"
+contender_git_commit <-  "ac2d207611ce25c91fb9fc90d5eaff2933609660"
 hardware_name <- "ursa-i9-9960x"
 
 library(dplyr)


### PR DESCRIPTION
This PR does a couple things as a follow up from #60, moving towards the goal of having this report as a runnable object for future releases:

- allows for a failure mode when no existent shas are provided. That will output a report that warns us of that.
- exclusively use a workflow dispatch as a trigger mechanism. The primary reason for this is then we can use the GitHub cli to trigger. For example something like this would trigger the report rendering action (from this branch):

```
gh workflow run performance-release-report.yml \
  --ref feat/perf-report2 \
  -f baseline_git_commit=6af660f48472b8b45a5e01b7136b9b040b185eb1 \
  -f contender_git_commit=ac2d207611ce25c91fb9fc90d5eaff2933609660 \
  -f rc_label=trigger_gh_cli
  ``` 

Tagging @assignUser and @raulcd as I can't request reviews. 
