### PR TITLE
Make trend plot interactive

### DIFF
--- a/.github/workflows/nightly_dashboard.yml
+++ b/.github/workflows/nightly_dashboard.yml
@@ -29,6 +29,8 @@ jobs:
           path: arrow
 
       - uses: actions/checkout@v3
+        with:
+          path: crossbow
 
       - name: Set up Python
         uses: actions/setup-python@v4

--- a/.github/workflows/nightly_dashboard.yml
+++ b/.github/workflows/nightly_dashboard.yml
@@ -41,7 +41,7 @@ jobs:
       - name: Generate List of Crossbow Tasks
         run: |
           python -m pip install -e arrow/dev/archery[crossbow]
-          archery crossbow check-config > all.yml
+          archery crossbow check-config > crossbow/all.yml
 
       - name: Setup Quarto
         uses: quarto-dev/quarto-actions/setup@v2

--- a/.github/workflows/nightly_dashboard.yml
+++ b/.github/workflows/nightly_dashboard.yml
@@ -10,13 +10,13 @@ on:
     paths:
       - "csv_reports/*.csv"
       - ".github/workflows/nightly_dashboard.yml"
-      - "crossbow-nightly-report.Rmd"
+      - "crossbow-nightly-report/crossbow-nightly-report.qmd"
   push:
     branches: main
     paths:
       - "csv_reports/*.csv"
       - ".github/workflows/nightly_dashboard.yml"
-      - "crossbow-nightly-report.Rmd"
+      - "crossbow-nightly-report/crossbow-nightly-report.qmd"
 
 jobs:
   build:
@@ -27,55 +27,60 @@ jobs:
         with:
           repository: apache/arrow
           path: arrow
+
       - uses: actions/checkout@v3
-        with:
-          path: crossbow
+
       - name: Set up Python
         uses: actions/setup-python@v4
         with:
           cache: pip
           python-version: 3.11
+
       - name: Generate List of Crossbow Tasks
         run: |
           python -m pip install -e arrow/dev/archery[crossbow]
-          archery crossbow check-config > crossbow/all.yml
+          archery crossbow check-config > all.yml
+
+      - name: Setup Quarto
+        uses: quarto-dev/quarto-actions/setup@v2
+        with:
+          version: '1.3.450'
+
       - uses: r-lib/actions/setup-r@v2
         with:
+          r-version: '4.3.1'
           use-public-rspm: true
-      - uses: r-lib/actions/setup-pandoc@v2
-      - uses: r-lib/actions/setup-r-dependencies@v2
+
+      # Needed due to https://github.com/r-lib/actions/issues/618
+      - name: Link renv.lock
+        run: ln -sf 'crossbow-nightly-report/renv.lock'
+
+      - name: Setup renv
+        uses: r-lib/actions/setup-renv@v2
+        env: 
+          # This is set by setup-r
+          RENV_CONFIG_REPOS_OVERRIDE: ""
         with:
-          dependencies: 'NA'
-          packages: |
-            any::rmarkdown
-            any::readr
-            any::rlang
-            any::ggplot2
-            any::gt
-            any::dplyr
-            any::glue
-            any::purrr
-            any::tidyr
-            any::cli
-            any::lubridate
-            any::tibble
-            any::yaml
+          cache-version: 1
       - name: Build Report
-        working-directory: crossbow
-        shell: Rscript {0}
-        run: |
-          rmarkdown::render("crossbow-nightly-report.Rmd", output_file = "index.html")
+        uses: quarto-dev/quarto-actions/render@v2
+        env:
+          CROSSBOW_LOOKBACK_WINDOW: 120
+        with:
+          to: html
+          path: 'crossbow-nightly-report/crossbow-nightly-report.qmd'
+
       - name: Upload Rendered Dashboard
         if: github.event_name == 'pull_request'
         uses: actions/upload-artifact@v3
         with:
           name: dashboard
           path: |
-            crossbow/index.html
-            crossbow/all.yml
+            crossbow-nightly-report/crossbow-nightly-report.html
+            all.yml
       - name: Upload result
         if: github.event_name == 'push'
-        working-directory: crossbow
+        working-directory: crossbow-nightly-report
         shell: bash
         env:
           AWS_ACCESS_KEY_ID: ${{ secrets.CROSSBOW_DOCS_AWS_ACCESS_KEY_ID }}
@@ -83,4 +88,4 @@ jobs:
           AWS_DEFAULT_REGION: ${{ secrets.CROSSBOW_DOCS_S3_BUCKET_REGION }}
           BUCKET: ${{ secrets.CROSSBOW_DOCS_S3_BUCKET }}
         run: |
-          aws s3 cp index.html $BUCKET/index.html 
+          aws s3 cp crossbow-nightly-report.html $BUCKET/index.html 

--- a/.github/workflows/nightly_dashboard.yml
+++ b/.github/workflows/nightly_dashboard.yml
@@ -55,7 +55,7 @@ jobs:
 
       # Needed due to https://github.com/r-lib/actions/issues/618
       - name: Link renv.lock
-        run: ln -sf 'crossbow-nightly-report/renv.lock'
+        run: ln -sf 'crossbow/crossbow-nightly-report/renv.lock'
 
       - name: Setup renv
         uses: r-lib/actions/setup-renv@v2
@@ -70,7 +70,7 @@ jobs:
           CROSSBOW_LOOKBACK_WINDOW: 120
         with:
           to: html
-          path: 'crossbow-nightly-report/crossbow-nightly-report.qmd'
+          path: 'crossbow/crossbow-nightly-report/crossbow-nightly-report.qmd'
 
       - name: Upload Rendered Dashboard
         if: github.event_name == 'pull_request'
@@ -78,11 +78,11 @@ jobs:
         with:
           name: dashboard
           path: |
-            crossbow-nightly-report/crossbow-nightly-report.html
-            all.yml
+            crossbow/crossbow-nightly-report/crossbow-nightly-report.html
+            crossbow/all.yml
       - name: Upload result
         if: github.event_name == 'push'
-        working-directory: crossbow-nightly-report
+        working-directory: crossbow
         shell: bash
         env:
           AWS_ACCESS_KEY_ID: ${{ secrets.CROSSBOW_DOCS_AWS_ACCESS_KEY_ID }}
@@ -90,4 +90,4 @@ jobs:
           AWS_DEFAULT_REGION: ${{ secrets.CROSSBOW_DOCS_S3_BUCKET_REGION }}
           BUCKET: ${{ secrets.CROSSBOW_DOCS_S3_BUCKET }}
         run: |
-          aws s3 cp crossbow-nightly-report.html $BUCKET/index.html 
+          aws s3 cp crossbow-nightly-report/crossbow-nightly-report.html $BUCKET/index.html 

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 performance-release-report.html
 crossbow-nightly-report.html
+crossbow-nightly-report_cache
+all.yml

--- a/README.md
+++ b/README.md
@@ -7,3 +7,6 @@ cron jobs, see the github actions workflows defined in this repository.
 
 For the triggered tasks see the nightly group of crossbow's
 [task definition file](https://github.com/apache/arrow/blob/main/dev/tasks/tasks.yml).
+
+
+Nightly report CSVs are stored on the `csv_reports` directory.

--- a/crossbow-nightly-report/.Rprofile
+++ b/crossbow-nightly-report/.Rprofile
@@ -1,0 +1,1 @@
+source("renv/activate.R")

--- a/crossbow-nightly-report/R/functions.R
+++ b/crossbow-nightly-report/R/functions.R
@@ -1,0 +1,129 @@
+is_dev <- function() {
+  Sys.getenv("GITHUB_ACTIONS") != "true"
+}
+
+dropdown_helper <- function(values, name, element_id) {
+  htmltools::tags$select(
+    # Set to undefined to clear the filter
+    onchange = glue("Reactable.setFilter('{element_id}', '{name}', event.target.value || undefined)"),
+    # "All" has an empty value to clear the filter, and is the default option
+    htmltools::tags$option(value = "", "All"),
+    lapply(unique(values), htmltools::tags$option),
+    "aria-label" = sprintf("Filter %s", name)
+  )
+}
+
+arrow_commit_links <- function(sha) {
+  glue("<a href='https://github.com/apache/arrow/commit/{sha}' target='_blank'>{substring(sha, 1, 7)}</a>")
+}
+
+arrow_compare_links <- function(sha1, sha2) {
+  comp_link <- glue("<a href='https://github.com/apache/arrow/compare/{sha1}...{sha2}' target='_blank'>{substring(sha1, 1, 7)}</a>")
+
+  if (rlang::is_empty(comp_link)) {
+    return(glue("Build has not yet been successful"))
+  }
+  return(comp_link)
+}
+
+format_links <- function(link) {
+  glue("<a href='{link}' target='_blank'>{basename(link)}</a>")
+}
+
+make_nice_names <- function(x) {
+  toTitleCase(gsub("_", " ", names(x)))
+}
+
+arrow_build_table <- function(nightly_data, type, task) {
+  type_task_data <- nightly_data %>%
+    filter(build_type == type) %>%
+    filter(task_name == task)
+
+  ## filter for when the most recent run is a failure 
+  ordered_only_recent_fails <- type_task_data %>%
+    filter(task_name %in% task_name[nightly_date == max(nightly_date) & task_status != "success"]) %>%
+    arrange(desc(nightly_date)) %>%
+    mutate(task_status = case_when(
+      task_status == "success" ~ "pass",
+      task_status == "failure" ~ "fail",
+      TRUE ~ task_status
+    ))
+
+  if (nrow(ordered_only_recent_fails) == 0) {
+    ## if there are no failures, return a version of the table that reflects that
+    days <- as.numeric(
+      difftime(
+        ymd(Sys.Date(), tz = "UTC"),
+        max(type_task_data$nightly_date)
+      )
+    )
+    success_df <- type_task_data %>%
+      slice_max(order_by = nightly_date) %>%
+      mutate(
+        since_last_successful_build = days,
+        last_successful_commit = arrow_commit_links(arrow_commit),
+        last_successful_build = glue("<a href='{build_links}' target='_blank'>{task_status}</a>"),
+        most_recent_status = "passing"
+      ) %>%
+      select(task_name, most_recent_status, since_last_successful_build, last_successful_commit, last_successful_build, build_type)
+    return(success_df)
+  }
+
+  ## find first failure index
+  idx_recent_fail <- rle(ordered_only_recent_fails$task_status)$lengths[1]
+
+  ## expand failure index and give it some names
+  failure_df <- tibble(fails_plus_one = seq(1, idx_recent_fail + 1)) %>%
+    mutate(fail_label = case_when(
+      fails_plus_one == idx_recent_fail ~ "first_failure",
+      fails_plus_one == 1 ~ "most_recent_failure",
+      fails_plus_one == idx_recent_fail + 1 ~ "last_successful_build",
+      TRUE ~ paste0(fails_plus_one, " days ago")
+    )) %>%
+    filter(fails_plus_one <= 9 | grepl("failure|build", fail_label))
+
+
+  ## inner_join to ordered data
+  df <- ordered_only_recent_fails %>%
+    rowid_to_column() %>%
+    inner_join(failure_df, by = c("rowid" = "fails_plus_one"))
+
+
+  if (all(type_task_data$task_status %in% "failure")) {
+    days <- NA_real_
+  } else {
+    ## days since last successful build (need to add one)
+    days <- sum(as.numeric(
+      difftime(
+        df$nightly_date[df$fail_label == "most_recent_failure"],
+        df$nightly_date[df$fail_label == "last_successful_build"]
+      )
+    ), 1)
+  }
+
+
+  get_commit <- function(label) {
+    df$arrow_commit[df$fail_label == label]
+  }
+
+  df %>%
+    arrange(desc(fail_label)) %>%
+    mutate(build_links = glue("<a href='{build_links}' target='_blank'>{task_status}</a>")) %>%
+    select(task_name, build_type, build_links, fail_label) %>%
+    pivot_wider(names_from = fail_label, values_from = build_links) %>%
+    mutate(
+      since_last_successful_build = days,
+      last_successful_commit = arrow_compare_links(get_commit("last_successful_build"), get_commit("first_failure")),
+      most_recent_status = "failing",
+      .after = build_type
+    )
+}
+
+crossbow_theme <- function(data, ...) {
+  data %>%
+    tab_options(
+      table.font.size = 14,
+      ...
+    ) %>% 
+    opt_all_caps()
+}

--- a/crossbow-nightly-report/crossbow-nightly-report.qmd
+++ b/crossbow-nightly-report/crossbow-nightly-report.qmd
@@ -40,7 +40,7 @@ library(tibble)
 library(lubridate)
 library(yaml)
 library(arrow)
-
+library(here)
 
 crossbow_theme <- function(data, ...) {
   data %>%
@@ -151,7 +151,6 @@ arrow_build_table <- function(nightly_data, type, task) {
 
 ```{r data load}
 #| messages: false
-#| cache: !expr is_dev()
 
 cols <- c(
   "task_name", "task_build_status", "build_links", "task_branch_name_on_the_crossbow_repo",
@@ -159,13 +158,15 @@ cols <- c(
 )
 
 ## Here is where we tidy the data until a 1 value 1 cell data structure
-nightly <- open_csv_dataset("../csv_reports") %>%
+nightly <- open_csv_dataset(here("csv_reports")) %>%
   mutate(file_path = add_filename()) %>%
   mutate(build_links = gsub("^(.*?),.*", "\\1", build_links)) %>% ## get rid of multiple build links
   mutate(build_links = gsub("\\?.*", "", gsub("\\['|'\\]|'", "", build_links))) %>% ## gets rid of the extra formatting
   mutate(nightly_name = gsub("\\.csv$", "", gsub("^.*/", "", file_path))) %>%
   mutate(build_type = str_to_title((gsub("[0-9]|nightly|-", "", nightly_name)))) %>%
   mutate(nightly_date = ymd(gsub(".*-(\\d{4}-\\d{2}-\\d{2})-.*", "\\1", nightly_name))) %>%
+  as_record_batch_reader() %>% 
+  filter(nightly_date >= ymd("2023-07-01")) %>% 
   collect() %>% 
   filter(nightly_date >= Sys.Date() - days(lookback_window))
 
@@ -352,7 +353,7 @@ trendPlot(passPctDateSub)
 ```{r build_status}
 #| results: "asis"
 # this file can be generated with `archery crossbow check-config > all.yml`
-tasks <- yaml.load_file("../../all.yml")
+tasks <- yaml.load_file(here("all.yml"))
 
 tests <- tasks$groups[["nightly-tests"]]
 packaging <- tasks$groups[["nightly-packaging"]]
@@ -415,6 +416,7 @@ for (.x in unique(build_table$build_type)) {
 
 ```{r error-logs}
 #| results: "asis"
+#| eval: false
 month_year_order <- rev(unique(format(sort(as.Date(nightly$nightly_date)), "%b %Y")))
 
 for (.x in month_year_order) {
@@ -424,8 +426,8 @@ for (.x in month_year_order) {
   cat(glue("\n## {.x}"), "\n")
 
   nightly_sub_tbl <- nightly_sub %>%
-    filter(task_status == "failure") %>%
-    select(nightly_date, task_name, build_type, build_links, task_branch_name = crossbow_branch_url) %>%
+    # filter(task_status == "failure") %>%
+    select(nightly_date, task_status, task_name, build_type, build_links, task_branch_name = crossbow_branch_url) %>%
     mutate(
       build_links = format_links(build_links),
       task_branch_name = format_links(task_branch_name)
@@ -435,6 +437,7 @@ for (.x in month_year_order) {
   names(nightly_sub_tbl) <- make_nice_names(nightly_sub_tbl)
 
   nightly_sub_tbl %>%
+    head(10) %>% 
     gt() %>%
     fmt_markdown(c("Build Links", "Task Branch Name")) %>%
     crossbow_theme() %>%

--- a/crossbow-nightly-report/crossbow-nightly-report.qmd
+++ b/crossbow-nightly-report/crossbow-nightly-report.qmd
@@ -85,6 +85,7 @@ arrow_build_table <- function(nightly_data, type, task) {
     filter(build_type == type) %>%
     filter(task_name == task)
 
+  ## filter for when the most recent run is a failure 
   ordered_only_recent_fails <- type_task_data %>%
     filter(task_name %in% task_name[nightly_date == max(nightly_date) & task_status != "success"]) %>%
     arrange(desc(nightly_date)) %>%
@@ -95,7 +96,23 @@ arrow_build_table <- function(nightly_data, type, task) {
     ))
 
   if (nrow(ordered_only_recent_fails) == 0) {
-    return(tibble())
+    ## if there are no failures, return a version of the table that reflects that
+    days <- as.numeric(
+      difftime(
+        ymd(Sys.Date(), tz = "UTC"),
+        max(type_task_data$nightly_date)
+      )
+    )
+    success_df <- type_task_data %>%
+      slice_max(order_by = nightly_date) %>%
+      mutate(
+        since_last_successful_build = days,
+        last_successful_commit = arrow_commit_links(arrow_commit),
+        last_successful_build = glue("<a href='{build_links}' target='_blank'>{task_status}</a>"),
+        most_recent_status = "passing"
+      ) %>%
+      select(task_name, most_recent_status, since_last_successful_build, last_successful_commit, last_successful_build, build_type)
+    return(success_df)
   }
 
   ## find first failure index
@@ -110,6 +127,7 @@ arrow_build_table <- function(nightly_data, type, task) {
       TRUE ~ paste0(fails_plus_one, " days ago")
     )) %>%
     filter(fails_plus_one <= 9 | grepl("failure|build", fail_label))
+
 
   ## inner_join to ordered data
   df <- ordered_only_recent_fails %>%
@@ -142,6 +160,7 @@ arrow_build_table <- function(nightly_data, type, task) {
     mutate(
       since_last_successful_build = days,
       last_successful_commit = arrow_compare_links(get_commit("last_successful_build"), get_commit("first_failure")),
+      most_recent_status = "failing",
       .after = build_type
     )
 }
@@ -374,7 +393,7 @@ for (.x in unique(build_table$build_type)) {
     filter(build_type == .x) %>%
     select(-build_type) %>%
     select(where(~ sum(!is.na(.x)) > 0)) %>% ## remove any columns with no data
-    arrange(desc(since_last_successful_build)) %>%
+    arrange(most_recent_status, desc(since_last_successful_build)) %>%
     rowwise() %>%
     mutate(
       since_last_successful_build = ifelse(

--- a/crossbow-nightly-report/crossbow-nightly-report.qmd
+++ b/crossbow-nightly-report/crossbow-nightly-report.qmd
@@ -350,7 +350,7 @@ trendPlot(passPctDateSub)
 ```{r build_status}
 #| results: "asis"
 # this file can be generated with `archery crossbow check-config > all.yml`
-tasks <- yaml.load_file("../all.yml")
+tasks <- yaml.load_file("../../all.yml")
 
 tests <- tasks$groups[["nightly-tests"]]
 packaging <- tasks$groups[["nightly-packaging"]]

--- a/crossbow-nightly-report/crossbow-nightly-report.qmd
+++ b/crossbow-nightly-report/crossbow-nightly-report.qmd
@@ -40,7 +40,6 @@ library(tibble)
 library(lubridate)
 library(yaml)
 library(arrow)
-library(here)
 
 crossbow_theme <- function(data, ...) {
   data %>%
@@ -52,7 +51,7 @@ crossbow_theme <- function(data, ...) {
 ```
 
 ```{r vars}
-lookback_window <- Sys.getenv("CROSSBOW_LOOKBACK_WINDOW", 120)
+lookback_window <- Sys.getenv("CROSSBOW_LOOKBACK_WINDOW", 200)
 ```
 
 ```{r helper}
@@ -158,7 +157,7 @@ cols <- c(
 )
 
 ## Here is where we tidy the data until a 1 value 1 cell data structure
-nightly <- open_csv_dataset(here("csv_reports")) %>%
+nightly <- open_csv_dataset("../csv_reports") %>%
   mutate(file_path = add_filename()) %>%
   mutate(build_links = gsub("^(.*?),.*", "\\1", build_links)) %>% ## get rid of multiple build links
   mutate(build_links = gsub("\\?.*", "", gsub("\\['|'\\]|'", "", build_links))) %>% ## gets rid of the extra formatting
@@ -176,7 +175,7 @@ most_recent_commit <- unique(nightly$arrow_commit[nightly$nightly_date == max(ni
 
 <a href='https://arrow.apache.org/'><img src='https://arrow.apache.org/img/arrow-logo_hex_black-txt_white-bg.png' align="right" height="150" /></a>
 
-This report builds in sync with the email notifications (`builds@arrow.apache.org`). `r pluralize('Most recent commit{?s}:  {arrow_commit_links(most_recent_commit)}')`
+This report builds in sync with the email notifications (`builds@arrow.apache.org`). `r pluralize('Most recent commit{?s} are:  {arrow_commit_links(most_recent_commit)}')`. The report examines data from the last `r lookback_window` days.
 
 
 # Summary 
@@ -353,7 +352,7 @@ trendPlot(passPctDateSub)
 ```{r build_status}
 #| results: "asis"
 # this file can be generated with `archery crossbow check-config > all.yml`
-tasks <- yaml.load_file(here("all.yml"))
+tasks <- yaml.load_file("../../all.yml")
 
 tests <- tasks$groups[["nightly-tests"]]
 packaging <- tasks$groups[["nightly-packaging"]]
@@ -426,7 +425,7 @@ for (.x in month_year_order) {
   cat(glue("\n## {.x}"), "\n")
 
   nightly_sub_tbl <- nightly_sub %>%
-    # filter(task_status == "failure") %>%
+    filter(task_status == "failure") %>%
     select(nightly_date, task_status, task_name, build_type, build_links, task_branch_name = crossbow_branch_url) %>%
     mutate(
       build_links = format_links(build_links),

--- a/crossbow-nightly-report/crossbow-nightly-report.qmd
+++ b/crossbow-nightly-report/crossbow-nightly-report.qmd
@@ -1,9 +1,24 @@
 ---
 title: "Crossbow Nightly Report"
-output: html_document
+execute: 
+  warning: false
+  echo: false
+format: 
+  html:
+    grid:
+        sidebar-width: 0px
+        body-width: 2000px
+        margin-width: 340px
+        gutter-width: 1.5rem
+    self-contained: true
+    page-layout: full
+    margin-left: 30px
+    link-external-newwindow: true
+    theme: cosmo
 ---
 
-```{r setup, include=FALSE}
+```{r setup}
+#| include: false
 knitr::opts_chunk$set(
   warning = FALSE,
   message = FALSE,
@@ -35,7 +50,15 @@ crossbow_theme <- function(data, ...) {
 }
 ```
 
+```{r vars}
+lookback_window <- Sys.getenv("CROSSBOW_LOOKBACK_WINDOW", 120)
+```
+
 ```{r helper}
+is_dev <- function() {
+  Sys.getenv("GITHUB_ACTIONS") != "true"
+}
+
 arrow_commit_links <- function(sha) {
   glue("<a href='https://github.com/apache/arrow/commit/{sha}' target='_blank'>{substring(sha, 1, 7)}</a>")
 }
@@ -126,18 +149,19 @@ arrow_build_table <- function(nightly_data, type, task) {
 
 
 ```{r data load}
-#| messages = FALSE
+#| messages: false
+#| cache: !expr is_dev()
 
 cols <- c(
   "task_name", "task_build_status", "build_links", "task_branch_name_on_the_crossbow_repo",
   "task_ci_type", "extra_params", "task_template_used", "arrow_repository_commit"
 )
 
-csv_paths <- list.files("csv_reports", pattern = "*.csv", full.names = TRUE) %>%
+csv_paths <- list.files("../csv_reports", pattern = "*.csv", full.names = TRUE) %>%
   set_names()
 
 ## Here is where we tidy the data until a 1 value 1 cell data structure
-nightly <- map_dfr(csv_paths, read_csv, .id = "file_path") %>%
+nightly <- map_dfr(csv_paths, read_csv, .id = "file_path", col_type = cols(.default = col_character())) %>%
   mutate(build_links = gsub("^(.*?),.*", "\\1", build_links)) %>% ## get rid of multiple build links
   mutate(build_links = gsub("\\?.*", "", gsub("\\['|'\\]|'", "", build_links))) %>% ## gets rid of the extra formatting
   mutate(nightly_name = file_path_sans_ext(basename(file_path))) %>%
@@ -200,34 +224,133 @@ nightly_summary %>%
 ```
 
 
-# Trend
-```{r table, echo=FALSE}
-pass_pct %>%
-  ggplot(aes(x = nightly_date, y = prop, group = build_type, colour = build_type)) +
-  geom_point(aes(shape = ifelse(prop == 1, "allpass", "fail"))) +
-  geom_smooth(method = "loess", formula = y ~ x, se = FALSE) +
-  geom_hline(yintercept = 1, colour = "grey", linetype = 3) +
-  labs(x = "Date", title = "Proportion of runs that are successful") +
-  guides(colour = "none", shape = "none") +
-  scale_colour_viridis_d() +
-  scale_shape_manual(values = c(17, 19)) +
-  scale_y_continuous(labels = scales::percent) +
-  scale_x_date(date_breaks = "2 weeks", date_labels = "%b %d") +
-  theme_minimal() +
-  theme(
-    axis.title.y = element_blank(),
-    plot.title.position = "plot",
-    strip.text = element_text(size = 12),
-    legend.title = element_blank()
-  ) +
-  facet_wrap(~build_type, nrow = 3)
+```{r ojs-hand-off}
+ojs_define(plot_end_date = max(pass_pct$nightly_date))# + days(7))
+ojs_define(plot_default_date = max(pass_pct$nightly_date) - days(lookback_window))
+ojs_define(ojs_pass_pct = pass_pct)
 ```
 
-# Build Status  {.tabset}
+# Trend
 
-```{r results="asis"}
+```{ojs functions}
+trendPlot = function(data) {
+  // variables to use
+  const spec = ({
+    x: "nightly_date", 
+    y: "prop", 
+    stroke: "build_type", 
+    fy: "build_type"
+  })
+
+  const added_spec = Object.assign(
+    {},
+    spec,
+    {
+      tip: true,
+      symbol: "circle",
+      fill: "build_type",  
+      opacity: 0.7
+    }
+  )
+
+  return Plot.plot({
+    width: 1200,
+    height: 600,
+    nice: true,
+    color: {scheme: "viridis"},
+    facet: {
+      data: data,
+      y: "build_type",
+      marginRight: 90,
+      marginLeft: 10,
+      },
+      fy: {
+        inset: 15,
+        padding: 0.1,
+        label: ""
+      },
+    y: {
+      domain: [0, 100],
+      label: "Proportion successful (%)",
+      percent: true
+    },
+    x: {
+      type: "utc",
+      label: "",
+      tickFormat: "%b '%y",
+    },
+    style: {
+      fontSize: "16px"
+    },
+    marks: [
+      Plot.lineY(data, Plot.windowY(10, spec)),
+      Plot.frame(),
+      Plot.dot(data, added_spec),
+      Plot.axisX({ticks: d3.utcMonth.every(1), tickFormat: " %b", tickSize: 14, tickPadding: -10, textAnchor: "start"}),
+      Plot.axisX({ticks: d3.utcYear, tickFormat: "\n %Y", tickSize: 24, tickPadding: -20, textAnchor: "start"}),
+      Plot.gridX({ticks: d3.utcMonth})
+      ]
+    })
+}
+```
+
+```{ojs setup-ojs}
+// import newer observable
+Plot = await import("https://esm.sh/@observablehq/plot");
+import { aq, op } from '@uwdata/arquero';
+parser = d3.timeParse("%Y-%m-%d");
+import {slider as slide} from "@jashkenas/inputs"; // more configurable slider
+timeScale = d3.scaleTime()
+    .domain([initialPlotStartDate, plotEndDate])
+    .range([0, d3.timeDay.count(initialPlotStartDate, plotEndDate)]); 
+
+passPct = aq.from(transpose(ojs_pass_pct))
+  .derive({ nightly_date: aq.escape(d => parser(d.nightly_date)) })
+```
+
+```{ojs date-slider}
+minNightlyDate = passPct
+  .rollup({
+    min_nightly_date: d => op.min(d.nightly_date)
+  })
+  .array('min_nightly_date')
+
+// Slider for date
+initialPlotStartDate = new Date(minNightlyDate)
+plotEndDate = new Date(plot_end_date)
+plotDefaultDate = new Date(plot_default_date)
+
+// a slider that starts at the default date (value of CROSSBOW_LOOKBACK_WINDOW)
+viewof slider = slide({
+  min: 0, 
+  max: d3.timeDay.count(initialPlotStartDate, plotEndDate), 
+  format: d => md`${d3.timeFormat("%B %d, %Y")(timeScale.invert(d))}`,
+  title: "Plot minimum date", 
+  value: d3.timeDay.count(initialPlotStartDate, plotDefaultDate),
+  step: 2
+})
+
+// turn slide number back into a date
+date = timeScale.invert(slider)
+```
+
+```{ojs trend-plot}
+//| echo: false
+
+passPctDateSub = passPct
+  .filter(aq.escape(d => d.nightly_date > date))
+
+trendPlot(passPctDateSub)
+```
+
+# Build Status  
+
+::: {.panel-tabset}
+
+```{r build_status}
+#| results: "asis"
 # this file can be generated with `archery crossbow check-config > all.yml`
-tasks <- yaml.load_file("all.yml")
+tasks <- yaml.load_file("../all.yml")
 
 tests <- tasks$groups[["nightly-tests"]]
 packaging <- tasks$groups[["nightly-packaging"]]
@@ -280,12 +403,16 @@ for (.x in unique(build_table$build_type)) {
 }
 ```
 
+:::
 
 
 
-# Error Logs {.tabset}
+# Error Logs
 
-```{r error-logs, results='asis'}
+::: {.panel-tabset}
+
+```{r error-logs}
+#| results: "asis"
 month_year_order <- rev(unique(format(sort(as.Date(nightly$nightly_date)), "%b %Y")))
 
 for (.x in month_year_order) {
@@ -312,3 +439,5 @@ for (.x in month_year_order) {
     print()
 }
 ```
+
+:::

--- a/crossbow-nightly-report/crossbow-nightly-report.qmd
+++ b/crossbow-nightly-report/crossbow-nightly-report.qmd
@@ -260,8 +260,8 @@ nightly_summary %>%
 
 
 ```{r ojs-hand-off}
-ojs_define(plot_end_date = max(pass_pct$nightly_date))# + days(7))
-ojs_define(plot_default_date = max(pass_pct$nightly_date) - days(14))
+ojs_define(plot_end_date = max(pass_pct$nightly_date))
+ojs_define(plot_default_date = max(pass_pct$nightly_date) - months(1))
 ojs_define(ojs_pass_pct = pass_pct)
 ```
 
@@ -291,6 +291,7 @@ trendPlot = function(data) {
   return Plot.plot({
     width: 1200,
     height: 600,
+    inset: 10, 
     nice: true,
     color: {scheme: "viridis"},
     facet: {
@@ -307,11 +308,12 @@ trendPlot = function(data) {
     y: {
       domain: [0, 100],
       label: "Proportion successful (%)",
-      percent: true
+      percent: true,
+      labelOffset: 40
     },
     x: {
       type: "utc",
-      label: "",
+      label: "Date",
       tickFormat: "%b '%y",
     },
     style: {
@@ -321,7 +323,7 @@ trendPlot = function(data) {
       Plot.lineY(data, Plot.windowY(10, spec)),
       Plot.frame(),
       Plot.dot(data, added_spec),
-      Plot.axisX({ticks: d3.utcMonth.every(1), tickFormat: " %b", tickSize: 14, tickPadding: -10, textAnchor: "start"}),
+      Plot.axisX({ticks: d3.utcMonth.every(1), tickFormat: " %b %d", tickSize: 14, tickPadding: -8, textAnchor: "start"}),
       Plot.axisX({ticks: d3.utcYear, tickFormat: "\n %Y", tickSize: 24, tickPadding: -20, textAnchor: "start"}),
       Plot.gridX({ticks: d3.utcMonth})
       ]

--- a/crossbow-nightly-report/crossbow-nightly-report.qmd
+++ b/crossbow-nightly-report/crossbow-nightly-report.qmd
@@ -43,140 +43,11 @@ library(arrow)
 library(reactable)
 library(htmltools)
 
-crossbow_theme <- function(data, ...) {
-  data %>%
-    tab_options(
-      table.font.size = 14,
-      ...
-    )
-}
+source("R/functions.R")
 ```
 
 ```{r vars}
 lookback_window <- Sys.getenv("CROSSBOW_LOOKBACK_WINDOW", 120)
-```
-
-```{r helper}
-is_dev <- function() {
-  Sys.getenv("GITHUB_ACTIONS") != "true"
-}
-
-search_drop_down_column <- function(values, name, custom = FALSE) {
-  htmltools::tags$select(
-    # Set to undefined to clear the filter
-    onchange = sprintf("Reactable.setFilter('name-select', '%s', event.target.value || undefined)", name),
-    # "All" has an empty value to clear the filter, and is the default option
-    htmltools::tags$option(value = "", "All"),
-    lapply(unique(values), htmltools::tags$option),
-    "aria-label" = sprintf("Filter %s", name)
-  )
-}
-
-arrow_commit_links <- function(sha) {
-  glue("<a href='https://github.com/apache/arrow/commit/{sha}' target='_blank'>{substring(sha, 1, 7)}</a>")
-}
-
-arrow_compare_links <- function(sha1, sha2) {
-  comp_link <- glue("<a href='https://github.com/apache/arrow/compare/{sha1}...{sha2}' target='_blank'>{substring(sha1, 1, 7)}</a>")
-
-  if (rlang::is_empty(comp_link)) {
-    return(glue("Build has not yet been successful"))
-  }
-  return(comp_link)
-}
-
-format_links <- function(link) {
-  glue("<a href='{link}' target='_blank'>{basename(link)}</a>")
-}
-
-make_nice_names <- function(x) {
-  toTitleCase(gsub("_", " ", names(x)))
-}
-
-arrow_build_table <- function(nightly_data, type, task) {
-  type_task_data <- nightly_data %>%
-    filter(build_type == type) %>%
-    filter(task_name == task)
-
-  ## filter for when the most recent run is a failure 
-  ordered_only_recent_fails <- type_task_data %>%
-    filter(task_name %in% task_name[nightly_date == max(nightly_date) & task_status != "success"]) %>%
-    arrange(desc(nightly_date)) %>%
-    mutate(task_status = case_when(
-      task_status == "success" ~ "pass",
-      task_status == "failure" ~ "fail",
-      TRUE ~ task_status
-    ))
-
-  if (nrow(ordered_only_recent_fails) == 0) {
-    ## if there are no failures, return a version of the table that reflects that
-    days <- as.numeric(
-      difftime(
-        ymd(Sys.Date(), tz = "UTC"),
-        max(type_task_data$nightly_date)
-      )
-    )
-    success_df <- type_task_data %>%
-      slice_max(order_by = nightly_date) %>%
-      mutate(
-        since_last_successful_build = days,
-        last_successful_commit = arrow_commit_links(arrow_commit),
-        last_successful_build = glue("<a href='{build_links}' target='_blank'>{task_status}</a>"),
-        most_recent_status = "passing"
-      ) %>%
-      select(task_name, most_recent_status, since_last_successful_build, last_successful_commit, last_successful_build, build_type)
-    return(success_df)
-  }
-
-  ## find first failure index
-  idx_recent_fail <- rle(ordered_only_recent_fails$task_status)$lengths[1]
-
-  ## expand failure index and give it some names
-  failure_df <- tibble(fails_plus_one = seq(1, idx_recent_fail + 1)) %>%
-    mutate(fail_label = case_when(
-      fails_plus_one == idx_recent_fail ~ "first_failure",
-      fails_plus_one == 1 ~ "most_recent_failure",
-      fails_plus_one == idx_recent_fail + 1 ~ "last_successful_build",
-      TRUE ~ paste0(fails_plus_one, " days ago")
-    )) %>%
-    filter(fails_plus_one <= 9 | grepl("failure|build", fail_label))
-
-
-  ## inner_join to ordered data
-  df <- ordered_only_recent_fails %>%
-    rowid_to_column() %>%
-    inner_join(failure_df, by = c("rowid" = "fails_plus_one"))
-
-
-  if (all(type_task_data$task_status %in% "failure")) {
-    days <- NA_real_
-  } else {
-    ## days since last successful build (need to add one)
-    days <- sum(as.numeric(
-      difftime(
-        df$nightly_date[df$fail_label == "most_recent_failure"],
-        df$nightly_date[df$fail_label == "last_successful_build"]
-      )
-    ), 1)
-  }
-
-
-  get_commit <- function(label) {
-    df$arrow_commit[df$fail_label == label]
-  }
-
-  df %>%
-    arrange(desc(fail_label)) %>%
-    mutate(build_links = glue("<a href='{build_links}' target='_blank'>{task_status}</a>")) %>%
-    select(task_name, build_type, build_links, fail_label) %>%
-    pivot_wider(names_from = fail_label, values_from = build_links) %>%
-    mutate(
-      since_last_successful_build = days,
-      last_successful_commit = arrow_compare_links(get_commit("last_successful_build"), get_commit("first_failure")),
-      most_recent_status = "failing",
-      .after = build_type
-    )
-}
 ```
 
 
@@ -255,7 +126,8 @@ nightly_summary %>%
     locations = cells_column_labels(
       columns = `Failure Trend`
     )
-  )
+  ) %>% 
+  opt_all_caps()
 ```
 
 

--- a/crossbow-nightly-report/crossbow-nightly-report.qmd
+++ b/crossbow-nightly-report/crossbow-nightly-report.qmd
@@ -53,7 +53,7 @@ crossbow_theme <- function(data, ...) {
 ```
 
 ```{r vars}
-lookback_window <- Sys.getenv("CROSSBOW_LOOKBACK_WINDOW", 200)
+lookback_window <- Sys.getenv("CROSSBOW_LOOKBACK_WINDOW", 120)
 ```
 
 ```{r helper}
@@ -188,6 +188,8 @@ cols <- c(
   "task_ci_type", "extra_params", "task_template_used", "arrow_repository_commit"
 )
 
+lookback_date <- Sys.Date() - days(lookback_window)
+
 ## Here is where we tidy the data until a 1 value 1 cell data structure
 nightly <- open_csv_dataset("../csv_reports") %>%
   mutate(file_path = add_filename()) %>%
@@ -197,9 +199,8 @@ nightly <- open_csv_dataset("../csv_reports") %>%
   mutate(build_type = str_to_title((gsub("[0-9]|nightly|-", "", nightly_name)))) %>%
   mutate(nightly_date = ymd(gsub(".*-(\\d{4}-\\d{2}-\\d{2})-.*", "\\1", nightly_name))) %>%
   as_record_batch_reader() %>% 
-  filter(nightly_date >= ymd("2023-07-01")) %>% 
-  collect() %>% 
-  filter(nightly_date >= Sys.Date() - days(lookback_window))
+  filter(nightly_date >= lookback_date) %>% 
+  collect() 
 
 
 most_recent_commit <- unique(nightly$arrow_commit[nightly$nightly_date == max(nightly$nightly_date)])

--- a/crossbow-nightly-report/crossbow-nightly-report.qmd
+++ b/crossbow-nightly-report/crossbow-nightly-report.qmd
@@ -39,6 +39,7 @@ library(tools)
 library(tibble)
 library(lubridate)
 library(yaml)
+library(arrow)
 
 
 crossbow_theme <- function(data, ...) {
@@ -157,16 +158,17 @@ cols <- c(
   "task_ci_type", "extra_params", "task_template_used", "arrow_repository_commit"
 )
 
-csv_paths <- list.files("../csv_reports", pattern = "*.csv", full.names = TRUE) %>%
-  set_names()
-
 ## Here is where we tidy the data until a 1 value 1 cell data structure
-nightly <- map_dfr(csv_paths, read_csv, .id = "file_path", col_type = cols(.default = col_character())) %>%
+nightly <- open_csv_dataset("../csv_reports") %>%
+  mutate(file_path = add_filename()) %>%
   mutate(build_links = gsub("^(.*?),.*", "\\1", build_links)) %>% ## get rid of multiple build links
   mutate(build_links = gsub("\\?.*", "", gsub("\\['|'\\]|'", "", build_links))) %>% ## gets rid of the extra formatting
-  mutate(nightly_name = file_path_sans_ext(basename(file_path))) %>%
-  mutate(build_type = toTitleCase(gsub("[0-9]|nightly|-", "", nightly_name))) %>%
-  mutate(nightly_date = as.Date(gsub("nightly-packaging-|nightly-release-|nightly-tests-", "", nightly_name)))
+  mutate(nightly_name = gsub("\\.csv$", "", gsub("^.*/", "", file_path))) %>%
+  mutate(build_type = str_to_title((gsub("[0-9]|nightly|-", "", nightly_name)))) %>%
+  mutate(nightly_date = ymd(gsub(".*-(\\d{4}-\\d{2}-\\d{2})-.*", "\\1", nightly_name))) %>%
+  collect() %>% 
+  filter(nightly_date >= Sys.Date() - days(lookback_window))
+
 
 most_recent_commit <- unique(nightly$arrow_commit[nightly$nightly_date == max(nightly$nightly_date)])
 ```
@@ -226,7 +228,7 @@ nightly_summary %>%
 
 ```{r ojs-hand-off}
 ojs_define(plot_end_date = max(pass_pct$nightly_date))# + days(7))
-ojs_define(plot_default_date = max(pass_pct$nightly_date) - days(lookback_window))
+ojs_define(plot_default_date = max(pass_pct$nightly_date) - days(14))
 ojs_define(ojs_pass_pct = pass_pct)
 ```
 
@@ -349,7 +351,6 @@ trendPlot(passPctDateSub)
 
 ```{r build_status}
 #| results: "asis"
-#| eval: false
 # this file can be generated with `archery crossbow check-config > all.yml`
 tasks <- yaml.load_file("../../all.yml")
 
@@ -414,7 +415,6 @@ for (.x in unique(build_table$build_type)) {
 
 ```{r error-logs}
 #| results: "asis"
-#| eval: false
 month_year_order <- rev(unique(format(sort(as.Date(nightly$nightly_date)), "%b %Y")))
 
 for (.x in month_year_order) {

--- a/crossbow-nightly-report/crossbow-nightly-report.qmd
+++ b/crossbow-nightly-report/crossbow-nightly-report.qmd
@@ -352,7 +352,7 @@ trendPlot(passPctDateSub)
 ```{r build_status}
 #| results: "asis"
 # this file can be generated with `archery crossbow check-config > all.yml`
-tasks <- yaml.load_file("../../all.yml")
+tasks <- yaml.load_file("../all.yml")
 
 tests <- tasks$groups[["nightly-tests"]]
 packaging <- tasks$groups[["nightly-packaging"]]

--- a/crossbow-nightly-report/crossbow-nightly-report.qmd
+++ b/crossbow-nightly-report/crossbow-nightly-report.qmd
@@ -14,7 +14,7 @@ format:
     page-layout: full
     margin-left: 30px
     link-external-newwindow: true
-    theme: cosmo
+    theme: [cosmo, crossbow.scss]
 ---
 
 ```{r setup}
@@ -40,6 +40,8 @@ library(tibble)
 library(lubridate)
 library(yaml)
 library(arrow)
+library(reactable)
+library(htmltools)
 
 crossbow_theme <- function(data, ...) {
   data %>%
@@ -57,6 +59,17 @@ lookback_window <- Sys.getenv("CROSSBOW_LOOKBACK_WINDOW", 200)
 ```{r helper}
 is_dev <- function() {
   Sys.getenv("GITHUB_ACTIONS") != "true"
+}
+
+search_drop_down_column <- function(values, name, custom = FALSE) {
+  htmltools::tags$select(
+    # Set to undefined to clear the filter
+    onchange = sprintf("Reactable.setFilter('name-select', '%s', event.target.value || undefined)", name),
+    # "All" has an empty value to clear the filter, and is the default option
+    htmltools::tags$option(value = "", "All"),
+    lapply(unique(values), htmltools::tags$option),
+    "aria-label" = sprintf("Filter %s", name)
+  )
 }
 
 arrow_commit_links <- function(sha) {
@@ -366,10 +379,8 @@ trendPlot(passPctDateSub)
 
 # Build Status  
 
-::: {.panel-tabset}
-
 ```{r build_status}
-#| results: "asis"
+#| results: asis
 # this file can be generated with `archery crossbow check-config > all.yml`
 tasks <- yaml.load_file("../all.yml")
 
@@ -385,55 +396,104 @@ map_params <- nightly %>%
   filter(task_name %in% active_jobs)
 
 build_table <- map2_df(map_params$build_type, map_params$task_name, ~ arrow_build_table(nightly, type = .x, task = .y))
-
-for (.x in unique(build_table$build_type)) {
-  cat(glue("\n## {.x}"), "\n")
-
-  bs_nightly_tbl <- build_table %>%
-    filter(build_type == .x) %>%
-    select(-build_type) %>%
-    select(where(~ sum(!is.na(.x)) > 0)) %>% ## remove any columns with no data
-    arrange(most_recent_status, desc(since_last_successful_build)) %>%
-    rowwise() %>%
-    mutate(
-      since_last_successful_build = ifelse(
-        is.na(since_last_successful_build), "-",
-        pluralize("{since_last_successful_build} day{?s}")
-      )
-    )
-
-  ## Need to sort columns at this level because of variable fail dates
-  ## TODO: find something a little less hacky
-  bs_nightly_tbl <- bs_nightly_tbl[, rev(sort(names(bs_nightly_tbl)))] %>%
-    relocate(any_of("most_recent_failure"), .after = last_col()) %>%
-    relocate(any_of(c("last_successful_build", "first_failure")), .after = last_successful_commit)
-
-  names(bs_nightly_tbl) <- make_nice_names(bs_nightly_tbl)
-
-  bs_nightly_tbl %>%
-    gt() %>%
-    cols_align("left") %>%
-    cols_width(`Task Name` ~ px(300)) %>%
-    fmt_markdown(matches("success|failure|days")) %>%
-    sub_missing(
-      everything(),
-      missing_text = ""
-    ) %>%
-    crossbow_theme() %>%
-    print()
-}
 ```
 
-:::
 
+```{r build_table}
+bs_nightly_tbl <- build_table %>%
+  select(where(~ sum(!is.na(.x)) > 0)) %>% ## remove any columns with no data
+  arrange(build_type, most_recent_status, desc(since_last_successful_build)) %>%
+  rowwise() %>%
+  mutate(
+    since_last_successful_build = ifelse(
+      is.na(since_last_successful_build), "-",
+      pluralize("{since_last_successful_build} day{?s}")
+    )
+  ) %>%
+  ungroup()
 
+## Need to sort columns at this level because of variable fail dates
+## TODO: find something a little less hacky
+bs_nightly_tbl_sorted <- bs_nightly_tbl[, rev(sort(names(bs_nightly_tbl)))] %>%
+  relocate(any_of("most_recent_failure"), .after = last_col()) %>%
+  relocate(any_of(c("last_successful_build", "first_failure")), .after = last_successful_commit) %>%
+  relocate(build_type, .before = task_name)
+
+## set a row number such all the failing builds are always displayed
+tbl_row_n <- bs_nightly_tbl_sorted %>%
+  filter(most_recent_status == "failing") %>%
+  count(build_type) %>%
+  filter(n == max(n)) %>%
+  pull(n)
+
+names(bs_nightly_tbl_sorted) <- make_nice_names(bs_nightly_tbl_sorted)
+
+bs_nightly_tbl_sorted %>%
+  reactable(
+    filterable = TRUE,
+    highlight = TRUE,
+    wrap = TRUE,
+    # style = list(fontSize = "0.6rem"),
+    defaultPageSize = tbl_row_n,
+    rowStyle = function(index) {
+      if (bs_nightly_tbl_sorted[index, "Most Recent Status"] == "failing") {
+        list(background = "#ffe4e4")
+      } else {
+        list(background = "#d1e8ff")
+      }
+    },
+    defaultColDef = reactable::colDef(
+      html = TRUE, 
+      class = "bw_table_cells",
+      headerClass = "bw_table_header",
+      headerVAlign = "bottom",
+      width = 50
+      ),
+    columns = list(
+      `Build Type` = reactable::colDef(
+        width = 80,
+        filterInput = function(values, name) {
+          search_drop_down_column(values, name)
+        }
+      ),
+      `Task Name` = reactable::colDef(
+        width = 80
+      ),
+      `Since Last Successful Build` = reactable::colDef(
+        width = 100,
+        filterInput = function(values, name) {
+          search_drop_down_column(values, name)
+        }
+      ),
+      `Most Recent Status` = reactable::colDef(
+        width = 70,
+        filterInput = function(values, name) {
+          search_drop_down_column(values, name)
+        }
+      ),
+      `Last Successful Commit` = reactable::colDef(
+        width = 80
+      ),
+      `Last Successful Build` = reactable::colDef(
+        width = 80
+      ),
+      `First Failure` = reactable::colDef(
+        width = 60
+      ),
+      `Most Recent Failure` = reactable::colDef(
+        width = 60
+      )
+    ),
+    elementId = "name-select"
+  )
+```
 
 # Error Logs
 
 ::: {.panel-tabset}
 
 ```{r error-logs}
-#| results: "asis"
+#| results: asis
 month_year_order <- rev(unique(format(sort(as.Date(nightly$nightly_date)), "%b %Y")))
 
 for (.x in month_year_order) {

--- a/crossbow-nightly-report/crossbow-nightly-report.qmd
+++ b/crossbow-nightly-report/crossbow-nightly-report.qmd
@@ -415,7 +415,6 @@ for (.x in unique(build_table$build_type)) {
 
 ```{r error-logs}
 #| results: "asis"
-#| eval: false
 month_year_order <- rev(unique(format(sort(as.Date(nightly$nightly_date)), "%b %Y")))
 
 for (.x in month_year_order) {

--- a/crossbow-nightly-report/crossbow-nightly-report.qmd
+++ b/crossbow-nightly-report/crossbow-nightly-report.qmd
@@ -349,6 +349,7 @@ trendPlot(passPctDateSub)
 
 ```{r build_status}
 #| results: "asis"
+#| eval: false
 # this file can be generated with `archery crossbow check-config > all.yml`
 tasks <- yaml.load_file("../../all.yml")
 
@@ -413,6 +414,7 @@ for (.x in unique(build_table$build_type)) {
 
 ```{r error-logs}
 #| results: "asis"
+#| eval: false
 month_year_order <- rev(unique(format(sort(as.Date(nightly$nightly_date)), "%b %Y")))
 
 for (.x in month_year_order) {

--- a/crossbow-nightly-report/crossbow-nightly-report.qmd
+++ b/crossbow-nightly-report/crossbow-nightly-report.qmd
@@ -303,6 +303,9 @@ tbl_row_n <- bs_nightly_tbl_sorted %>%
 
 names(bs_nightly_tbl_sorted) <- make_nice_names(bs_nightly_tbl_sorted)
 
+## html element id
+build_element_id <- "build_status"
+
 bs_nightly_tbl_sorted %>%
   reactable(
     filterable = TRUE,
@@ -318,32 +321,32 @@ bs_nightly_tbl_sorted %>%
       }
     },
     defaultColDef = reactable::colDef(
-      html = TRUE, 
+      html = TRUE,
       class = "bw_table_cells",
       headerClass = "bw_table_header",
       headerVAlign = "bottom",
       width = 50
-      ),
+    ),
     columns = list(
       `Build Type` = reactable::colDef(
         width = 80,
         filterInput = function(values, name) {
-          search_drop_down_column(values, name)
+          dropdown_helper(values, name, build_element_id)
         }
       ),
       `Task Name` = reactable::colDef(
-        width = 80
+        width = 110
       ),
       `Since Last Successful Build` = reactable::colDef(
         width = 100,
         filterInput = function(values, name) {
-          search_drop_down_column(values, name)
+          dropdown_helper(values, name, build_element_id)
         }
       ),
       `Most Recent Status` = reactable::colDef(
         width = 70,
         filterInput = function(values, name) {
-          search_drop_down_column(values, name)
+          dropdown_helper(values, name, build_element_id)
         }
       ),
       `Last Successful Commit` = reactable::colDef(
@@ -359,42 +362,69 @@ bs_nightly_tbl_sorted %>%
         width = 60
       )
     ),
-    elementId = "name-select"
+    elementId = build_element_id
   )
 ```
 
-# Error Logs
-
-::: {.panel-tabset}
+# Logs
 
 ```{r error-logs}
 #| results: asis
-month_year_order <- rev(unique(format(sort(as.Date(nightly$nightly_date)), "%b %Y")))
+#| eval: true
 
-for (.x in month_year_order) {
-  nightly_sub <- nightly %>%
-    filter(format(as.Date(nightly_date), "%b %Y") %in% .x)
+error_element_id <- "error-logs-id"
+nightly_sub_tbl <- nightly %>%
+  select(nightly_date, task_status, task_name, build_type, build_links, task_branch_name = crossbow_branch_url) %>%
+  mutate(
+    build_links = format_links(build_links),
+    task_branch_name = format_links(task_branch_name)
+  ) %>%
+  arrange(desc(nightly_date))
 
-  cat(glue("\n## {.x}"), "\n")
+names(nightly_sub_tbl) <- make_nice_names(nightly_sub_tbl)
 
-  nightly_sub_tbl <- nightly_sub %>%
-    filter(task_status == "failure") %>%
-    select(nightly_date, task_status, task_name, build_type, build_links, task_branch_name = crossbow_branch_url) %>%
-    mutate(
-      build_links = format_links(build_links),
-      task_branch_name = format_links(task_branch_name)
-    ) %>%
-    arrange(desc(nightly_date))
-
-  names(nightly_sub_tbl) <- make_nice_names(nightly_sub_tbl)
-
-  nightly_sub_tbl %>%
-    head(10) %>% 
-    gt() %>%
-    fmt_markdown(c("Build Links", "Task Branch Name")) %>%
-    crossbow_theme() %>%
-    print()
-}
+nightly_sub_tbl %>%
+  reactable(
+    filterable = TRUE,
+    highlight = TRUE,
+    wrap = TRUE,
+    rowStyle = function(index) {
+      if (nightly_sub_tbl[index, "Task Status"] %in% c("failure", "error")) {
+        list(background = "#ffe4e4")
+      } else {
+        list(background = "#d1e8ff")
+      }
+    },
+    defaultColDef = reactable::colDef(
+      html = TRUE,
+      class = "bw_table_cells",
+      headerClass = "bw_table_header",
+      headerVAlign = "bottom",
+      width = 100
+    ),
+    columns = list(
+      `Task Status` = reactable::colDef(
+        width = 80,
+        filterInput = function(values, name) {
+          dropdown_helper(values, name, error_element_id)
+        }
+      ),
+      `Task Name` = reactable::colDef(
+        width = 200,
+        filterInput = function(values, name) {
+          dropdown_helper(values, name, error_element_id)
+        }
+      ),
+      `Build Type` = reactable::colDef(
+        width = 100,
+        filterInput = function(values, name) {
+          dropdown_helper(values, name, error_element_id)
+        }
+      ),
+      `Task Branch Name` = reactable::colDef(
+        width = 300
+      )
+    ),
+    elementId = error_element_id
+  )
 ```
-
-:::

--- a/crossbow-nightly-report/crossbow.scss
+++ b/crossbow-nightly-report/crossbow.scss
@@ -3,7 +3,9 @@
 // variables to change
 // https://github.com/twbs/bootstrap/blob/main/scss/_variables.scss
 
-
+// @import 'https://fonts.googleapis.com/css2?family=Atkinson+Hyperlegible:ital,wght@0,400;0,700;1,400;1,700&display=swap';
+@import 'https://fonts.googleapis.com/css2?family=Atkinson+Hyperlegible&display=swap';
+$font-family-sans-serif: "Atkinson Hyperlegible", sans-serif;
 
 /*-- scss:rules --*/
 

--- a/crossbow-nightly-report/crossbow.scss
+++ b/crossbow-nightly-report/crossbow.scss
@@ -1,0 +1,17 @@
+/*-- scss:defaults --*/
+
+// variables to change
+// https://github.com/twbs/bootstrap/blob/main/scss/_variables.scss
+
+
+
+/*-- scss:rules --*/
+
+.bw_table_cells {
+    font-size: 0.75rem;
+  }
+  
+  .bw_table_header {
+    font-size: 0.65rem;
+    text-transform: uppercase;
+  }

--- a/crossbow-nightly-report/renv.lock
+++ b/crossbow-nightly-report/renv.lock
@@ -88,6 +88,38 @@
       ],
       "Hash": "d1fa8fae6a47e88bb46d5152312bd8bd"
     },
+    "arrow": {
+      "Package": "arrow",
+      "Version": "12.0.1.1",
+      "Source": "Repository",
+      "Repository": "CRAN",
+      "Requirements": [
+        "R",
+        "R6",
+        "assertthat",
+        "bit64",
+        "cpp11",
+        "glue",
+        "methods",
+        "purrr",
+        "rlang",
+        "stats",
+        "tidyselect",
+        "utils",
+        "vctrs"
+      ],
+      "Hash": "9ff9955a1766e0bc3493f06d8f43c97e"
+    },
+    "assertthat": {
+      "Package": "assertthat",
+      "Version": "0.2.1",
+      "Source": "Repository",
+      "Repository": "RSPM",
+      "Requirements": [
+        "tools"
+      ],
+      "Hash": "50c838a310445e954bc13f26f26a6ecf"
+    },
     "base64enc": {
       "Package": "base64enc",
       "Version": "0.1-3",

--- a/crossbow-nightly-report/renv.lock
+++ b/crossbow-nightly-report/renv.lock
@@ -470,6 +470,16 @@
       ],
       "Hash": "b44addadb528a0d227794121c00572a0"
     },
+    "here": {
+      "Package": "here",
+      "Version": "1.0.1",
+      "Source": "Repository",
+      "Repository": "CRAN",
+      "Requirements": [
+        "rprojroot"
+      ],
+      "Hash": "24b224366f9c2e7534d2344d10d59211"
+    },
     "highr": {
       "Package": "highr",
       "Version": "0.10",
@@ -886,6 +896,16 @@
         "yaml"
       ],
       "Hash": "493df4ae51e2e984952ea4d5c75786a3"
+    },
+    "rprojroot": {
+      "Package": "rprojroot",
+      "Version": "2.0.3",
+      "Source": "Repository",
+      "Repository": "RSPM",
+      "Requirements": [
+        "R"
+      ],
+      "Hash": "1de7ab598047a87bba48434ba35d497d"
     },
     "sass": {
       "Package": "sass",

--- a/crossbow-nightly-report/renv.lock
+++ b/crossbow-nightly-report/renv.lock
@@ -1,0 +1,1113 @@
+{
+  "R": {
+    "Version": "4.3.1",
+    "Repositories": [
+      {
+        "Name": "CRAN",
+        "URL": "https://packagemanager.rstudio.com/all/latest"
+      },
+      {
+        "Name": "voltron data rpkg-repo",
+        "URL": "https://voltrondata.github.io/rpkg-repo"
+      }
+    ]
+  },
+  "Packages": {
+    "MASS": {
+      "Package": "MASS",
+      "Version": "7.3-60",
+      "Source": "Repository",
+      "Repository": "RSPM",
+      "Requirements": [
+        "R",
+        "grDevices",
+        "graphics",
+        "methods",
+        "stats",
+        "utils"
+      ],
+      "Hash": "a56a6365b3fa73293ea8d084be0d9bb0"
+    },
+    "Matrix": {
+      "Package": "Matrix",
+      "Version": "1.5-4.1",
+      "Source": "Repository",
+      "Repository": "CRAN",
+      "Requirements": [
+        "R",
+        "graphics",
+        "grid",
+        "lattice",
+        "methods",
+        "stats",
+        "utils"
+      ],
+      "Hash": "38082d362d317745fb932e13956dccbb"
+    },
+    "R6": {
+      "Package": "R6",
+      "Version": "2.5.1",
+      "Source": "Repository",
+      "Repository": "RSPM",
+      "Requirements": [
+        "R"
+      ],
+      "Hash": "470851b6d5d0ac559e9d01bb352b4021"
+    },
+    "RColorBrewer": {
+      "Package": "RColorBrewer",
+      "Version": "1.1-3",
+      "Source": "Repository",
+      "Repository": "RSPM",
+      "Requirements": [
+        "R"
+      ],
+      "Hash": "45f0398006e83a5b10b72a90663d8d8c"
+    },
+    "Rcpp": {
+      "Package": "Rcpp",
+      "Version": "1.0.10",
+      "Source": "Repository",
+      "Repository": "RSPM",
+      "Requirements": [
+        "methods",
+        "utils"
+      ],
+      "Hash": "e749cae40fa9ef469b6050959517453c"
+    },
+    "V8": {
+      "Package": "V8",
+      "Version": "4.3.0",
+      "Source": "Repository",
+      "Repository": "CRAN",
+      "Requirements": [
+        "Rcpp",
+        "curl",
+        "jsonlite",
+        "utils"
+      ],
+      "Hash": "d1fa8fae6a47e88bb46d5152312bd8bd"
+    },
+    "base64enc": {
+      "Package": "base64enc",
+      "Version": "0.1-3",
+      "Source": "Repository",
+      "Repository": "RSPM",
+      "Requirements": [
+        "R"
+      ],
+      "Hash": "543776ae6848fde2f48ff3816d0628bc"
+    },
+    "bigD": {
+      "Package": "bigD",
+      "Version": "0.2.0",
+      "Source": "Repository",
+      "Repository": "CRAN",
+      "Requirements": [
+        "R"
+      ],
+      "Hash": "93637e906f3fe962413912c956eb44db"
+    },
+    "bit": {
+      "Package": "bit",
+      "Version": "4.0.5",
+      "Source": "Repository",
+      "Repository": "CRAN",
+      "Requirements": [
+        "R"
+      ],
+      "Hash": "d242abec29412ce988848d0294b208fd"
+    },
+    "bit64": {
+      "Package": "bit64",
+      "Version": "4.0.5",
+      "Source": "Repository",
+      "Repository": "CRAN",
+      "Requirements": [
+        "R",
+        "bit",
+        "methods",
+        "stats",
+        "utils"
+      ],
+      "Hash": "9fe98599ca456d6552421db0d6772d8f"
+    },
+    "bitops": {
+      "Package": "bitops",
+      "Version": "1.0-7",
+      "Source": "Repository",
+      "Repository": "CRAN",
+      "Hash": "b7d8d8ee39869c18d8846a184dd8a1af"
+    },
+    "bslib": {
+      "Package": "bslib",
+      "Version": "0.4.2",
+      "Source": "Repository",
+      "Repository": "RSPM",
+      "Requirements": [
+        "R",
+        "base64enc",
+        "cachem",
+        "grDevices",
+        "htmltools",
+        "jquerylib",
+        "jsonlite",
+        "memoise",
+        "mime",
+        "rlang",
+        "sass"
+      ],
+      "Hash": "a7fbf03946ad741129dc81098722fca1"
+    },
+    "cachem": {
+      "Package": "cachem",
+      "Version": "1.0.8",
+      "Source": "Repository",
+      "Repository": "RSPM",
+      "Requirements": [
+        "fastmap",
+        "rlang"
+      ],
+      "Hash": "c35768291560ce302c0a6589f92e837d"
+    },
+    "cli": {
+      "Package": "cli",
+      "Version": "3.6.1",
+      "Source": "Repository",
+      "Repository": "RSPM",
+      "Requirements": [
+        "R",
+        "utils"
+      ],
+      "Hash": "89e6d8219950eac806ae0c489052048a"
+    },
+    "clipr": {
+      "Package": "clipr",
+      "Version": "0.8.0",
+      "Source": "Repository",
+      "Repository": "CRAN",
+      "Requirements": [
+        "utils"
+      ],
+      "Hash": "3f038e5ac7f41d4ac41ce658c85e3042"
+    },
+    "colorspace": {
+      "Package": "colorspace",
+      "Version": "2.1-0",
+      "Source": "Repository",
+      "Repository": "RSPM",
+      "Requirements": [
+        "R",
+        "grDevices",
+        "graphics",
+        "methods",
+        "stats"
+      ],
+      "Hash": "f20c47fd52fae58b4e377c37bb8c335b"
+    },
+    "commonmark": {
+      "Package": "commonmark",
+      "Version": "1.9.0",
+      "Source": "Repository",
+      "Repository": "RSPM",
+      "Hash": "d691c61bff84bd63c383874d2d0c3307"
+    },
+    "cpp11": {
+      "Package": "cpp11",
+      "Version": "0.4.3",
+      "Source": "Repository",
+      "Repository": "RSPM",
+      "Hash": "ed588261931ee3be2c700d22e94a29ab"
+    },
+    "crayon": {
+      "Package": "crayon",
+      "Version": "1.5.2",
+      "Source": "Repository",
+      "Repository": "RSPM",
+      "Requirements": [
+        "grDevices",
+        "methods",
+        "utils"
+      ],
+      "Hash": "e8a1e41acf02548751f45c718d55aa6a"
+    },
+    "curl": {
+      "Package": "curl",
+      "Version": "5.0.0",
+      "Source": "Repository",
+      "Repository": "RSPM",
+      "Requirements": [
+        "R"
+      ],
+      "Hash": "e4f97056611e8e6b8b852d13b7400cf1"
+    },
+    "digest": {
+      "Package": "digest",
+      "Version": "0.6.31",
+      "Source": "Repository",
+      "Repository": "RSPM",
+      "Requirements": [
+        "R",
+        "utils"
+      ],
+      "Hash": "8b708f296afd9ae69f450f9640be8990"
+    },
+    "dplyr": {
+      "Package": "dplyr",
+      "Version": "1.1.2",
+      "Source": "Repository",
+      "Repository": "RSPM",
+      "Requirements": [
+        "R",
+        "R6",
+        "cli",
+        "generics",
+        "glue",
+        "lifecycle",
+        "magrittr",
+        "methods",
+        "pillar",
+        "rlang",
+        "tibble",
+        "tidyselect",
+        "utils",
+        "vctrs"
+      ],
+      "Hash": "dea6970ff715ca541c387de363ff405e"
+    },
+    "ellipsis": {
+      "Package": "ellipsis",
+      "Version": "0.3.2",
+      "Source": "Repository",
+      "Repository": "RSPM",
+      "Requirements": [
+        "R",
+        "rlang"
+      ],
+      "Hash": "bb0eec2fe32e88d9e2836c2f73ea2077"
+    },
+    "evaluate": {
+      "Package": "evaluate",
+      "Version": "0.21",
+      "Source": "Repository",
+      "Repository": "RSPM",
+      "Requirements": [
+        "R",
+        "methods"
+      ],
+      "Hash": "d59f3b464e8da1aef82dc04b588b8dfb"
+    },
+    "fansi": {
+      "Package": "fansi",
+      "Version": "1.0.4",
+      "Source": "Repository",
+      "Repository": "RSPM",
+      "Requirements": [
+        "R",
+        "grDevices",
+        "utils"
+      ],
+      "Hash": "1d9e7ad3c8312a192dea7d3db0274fde"
+    },
+    "farver": {
+      "Package": "farver",
+      "Version": "2.1.1",
+      "Source": "Repository",
+      "Repository": "RSPM",
+      "Hash": "8106d78941f34855c440ddb946b8f7a5"
+    },
+    "fastmap": {
+      "Package": "fastmap",
+      "Version": "1.1.1",
+      "Source": "Repository",
+      "Repository": "RSPM",
+      "Hash": "f7736a18de97dea803bde0a2daaafb27"
+    },
+    "fontawesome": {
+      "Package": "fontawesome",
+      "Version": "0.5.1",
+      "Source": "Repository",
+      "Repository": "RSPM",
+      "Requirements": [
+        "R",
+        "htmltools",
+        "rlang"
+      ],
+      "Hash": "1e22b8cabbad1eae951a75e9f8b52378"
+    },
+    "fs": {
+      "Package": "fs",
+      "Version": "1.6.2",
+      "Source": "Repository",
+      "Repository": "RSPM",
+      "Requirements": [
+        "R",
+        "methods"
+      ],
+      "Hash": "94af08e0aa9675a16fadbb3aaaa90d2a"
+    },
+    "generics": {
+      "Package": "generics",
+      "Version": "0.1.3",
+      "Source": "Repository",
+      "Repository": "RSPM",
+      "Requirements": [
+        "R",
+        "methods"
+      ],
+      "Hash": "15e9634c0fcd294799e9b2e929ed1b86"
+    },
+    "ggplot2": {
+      "Package": "ggplot2",
+      "Version": "3.4.2",
+      "Source": "Repository",
+      "Repository": "RSPM",
+      "Requirements": [
+        "MASS",
+        "R",
+        "cli",
+        "glue",
+        "grDevices",
+        "grid",
+        "gtable",
+        "isoband",
+        "lifecycle",
+        "mgcv",
+        "rlang",
+        "scales",
+        "stats",
+        "tibble",
+        "vctrs",
+        "withr"
+      ],
+      "Hash": "3a147ee02e85a8941aad9909f1b43b7b"
+    },
+    "glue": {
+      "Package": "glue",
+      "Version": "1.6.2",
+      "Source": "Repository",
+      "Repository": "RSPM",
+      "Requirements": [
+        "R",
+        "methods"
+      ],
+      "Hash": "4f2596dfb05dac67b9dc558e5c6fba2e"
+    },
+    "gt": {
+      "Package": "gt",
+      "Version": "0.9.0",
+      "Source": "Repository",
+      "Repository": "CRAN",
+      "Requirements": [
+        "R",
+        "base64enc",
+        "bigD",
+        "bitops",
+        "cli",
+        "commonmark",
+        "dplyr",
+        "fs",
+        "glue",
+        "htmltools",
+        "htmlwidgets",
+        "juicyjuice",
+        "magrittr",
+        "markdown",
+        "reactable",
+        "rlang",
+        "sass",
+        "scales",
+        "tibble",
+        "tidyselect",
+        "xml2"
+      ],
+      "Hash": "d55233a737e43e44987724e57dfec302"
+    },
+    "gtable": {
+      "Package": "gtable",
+      "Version": "0.3.3",
+      "Source": "Repository",
+      "Repository": "RSPM",
+      "Requirements": [
+        "R",
+        "cli",
+        "glue",
+        "grid",
+        "lifecycle",
+        "rlang"
+      ],
+      "Hash": "b44addadb528a0d227794121c00572a0"
+    },
+    "highr": {
+      "Package": "highr",
+      "Version": "0.10",
+      "Source": "Repository",
+      "Repository": "RSPM",
+      "Requirements": [
+        "R",
+        "xfun"
+      ],
+      "Hash": "06230136b2d2b9ba5805e1963fa6e890"
+    },
+    "hms": {
+      "Package": "hms",
+      "Version": "1.1.3",
+      "Source": "Repository",
+      "Repository": "CRAN",
+      "Requirements": [
+        "lifecycle",
+        "methods",
+        "pkgconfig",
+        "rlang",
+        "vctrs"
+      ],
+      "Hash": "b59377caa7ed00fa41808342002138f9"
+    },
+    "htmltools": {
+      "Package": "htmltools",
+      "Version": "0.5.5",
+      "Source": "Repository",
+      "Repository": "RSPM",
+      "Requirements": [
+        "R",
+        "base64enc",
+        "digest",
+        "ellipsis",
+        "fastmap",
+        "grDevices",
+        "rlang",
+        "utils"
+      ],
+      "Hash": "ba0240784ad50a62165058a27459304a"
+    },
+    "htmlwidgets": {
+      "Package": "htmlwidgets",
+      "Version": "1.6.2",
+      "Source": "Repository",
+      "Repository": "CRAN",
+      "Requirements": [
+        "grDevices",
+        "htmltools",
+        "jsonlite",
+        "knitr",
+        "rmarkdown",
+        "yaml"
+      ],
+      "Hash": "a865aa85bcb2697f47505bfd70422471"
+    },
+    "isoband": {
+      "Package": "isoband",
+      "Version": "0.2.7",
+      "Source": "Repository",
+      "Repository": "RSPM",
+      "Requirements": [
+        "grid",
+        "utils"
+      ],
+      "Hash": "0080607b4a1a7b28979aecef976d8bc2"
+    },
+    "jquerylib": {
+      "Package": "jquerylib",
+      "Version": "0.1.4",
+      "Source": "Repository",
+      "Repository": "RSPM",
+      "Requirements": [
+        "htmltools"
+      ],
+      "Hash": "5aab57a3bd297eee1c1d862735972182"
+    },
+    "jsonlite": {
+      "Package": "jsonlite",
+      "Version": "1.8.4",
+      "Source": "Repository",
+      "Repository": "RSPM",
+      "Requirements": [
+        "methods"
+      ],
+      "Hash": "a4269a09a9b865579b2635c77e572374"
+    },
+    "juicyjuice": {
+      "Package": "juicyjuice",
+      "Version": "0.1.0",
+      "Source": "Repository",
+      "Repository": "CRAN",
+      "Requirements": [
+        "V8"
+      ],
+      "Hash": "3bcd11943da509341838da9399e18bce"
+    },
+    "knitr": {
+      "Package": "knitr",
+      "Version": "1.42",
+      "Source": "Repository",
+      "Repository": "CRAN",
+      "Requirements": [
+        "R",
+        "evaluate",
+        "highr",
+        "methods",
+        "tools",
+        "xfun",
+        "yaml"
+      ],
+      "Hash": "8329a9bcc82943c8069104d4be3ee22d"
+    },
+    "labeling": {
+      "Package": "labeling",
+      "Version": "0.4.2",
+      "Source": "Repository",
+      "Repository": "RSPM",
+      "Requirements": [
+        "graphics",
+        "stats"
+      ],
+      "Hash": "3d5108641f47470611a32d0bdf357a72"
+    },
+    "lattice": {
+      "Package": "lattice",
+      "Version": "0.21-8",
+      "Source": "Repository",
+      "Repository": "CRAN",
+      "Requirements": [
+        "R",
+        "grDevices",
+        "graphics",
+        "grid",
+        "stats",
+        "utils"
+      ],
+      "Hash": "0b8a6d63c8770f02a8b5635f3c431e6b"
+    },
+    "lifecycle": {
+      "Package": "lifecycle",
+      "Version": "1.0.3",
+      "Source": "Repository",
+      "Repository": "RSPM",
+      "Requirements": [
+        "R",
+        "cli",
+        "glue",
+        "rlang"
+      ],
+      "Hash": "001cecbeac1cff9301bdc3775ee46a86"
+    },
+    "lubridate": {
+      "Package": "lubridate",
+      "Version": "1.9.2",
+      "Source": "Repository",
+      "Repository": "CRAN",
+      "Requirements": [
+        "R",
+        "generics",
+        "methods",
+        "timechange"
+      ],
+      "Hash": "e25f18436e3efd42c7c590a1c4c15390"
+    },
+    "magrittr": {
+      "Package": "magrittr",
+      "Version": "2.0.3",
+      "Source": "Repository",
+      "Repository": "RSPM",
+      "Requirements": [
+        "R"
+      ],
+      "Hash": "7ce2733a9826b3aeb1775d56fd305472"
+    },
+    "markdown": {
+      "Package": "markdown",
+      "Version": "1.7",
+      "Source": "Repository",
+      "Repository": "CRAN",
+      "Requirements": [
+        "R",
+        "commonmark",
+        "utils",
+        "xfun"
+      ],
+      "Hash": "0ffaea87c070a56d140ce00b0727b278"
+    },
+    "memoise": {
+      "Package": "memoise",
+      "Version": "2.0.1",
+      "Source": "Repository",
+      "Repository": "RSPM",
+      "Requirements": [
+        "cachem",
+        "rlang"
+      ],
+      "Hash": "e2817ccf4a065c5d9d7f2cfbe7c1d78c"
+    },
+    "mgcv": {
+      "Package": "mgcv",
+      "Version": "1.8-42",
+      "Source": "Repository",
+      "Repository": "CRAN",
+      "Requirements": [
+        "Matrix",
+        "R",
+        "graphics",
+        "methods",
+        "nlme",
+        "splines",
+        "stats",
+        "utils"
+      ],
+      "Hash": "3460beba7ccc8946249ba35327ba902a"
+    },
+    "mime": {
+      "Package": "mime",
+      "Version": "0.12",
+      "Source": "Repository",
+      "Repository": "RSPM",
+      "Requirements": [
+        "tools"
+      ],
+      "Hash": "18e9c28c1d3ca1560ce30658b22ce104"
+    },
+    "munsell": {
+      "Package": "munsell",
+      "Version": "0.5.0",
+      "Source": "Repository",
+      "Repository": "RSPM",
+      "Requirements": [
+        "colorspace",
+        "methods"
+      ],
+      "Hash": "6dfe8bf774944bd5595785e3229d8771"
+    },
+    "nlme": {
+      "Package": "nlme",
+      "Version": "3.1-162",
+      "Source": "Repository",
+      "Repository": "CRAN",
+      "Requirements": [
+        "R",
+        "graphics",
+        "lattice",
+        "stats",
+        "utils"
+      ],
+      "Hash": "0984ce8da8da9ead8643c5cbbb60f83e"
+    },
+    "pillar": {
+      "Package": "pillar",
+      "Version": "1.9.0",
+      "Source": "Repository",
+      "Repository": "RSPM",
+      "Requirements": [
+        "cli",
+        "fansi",
+        "glue",
+        "lifecycle",
+        "rlang",
+        "utf8",
+        "utils",
+        "vctrs"
+      ],
+      "Hash": "15da5a8412f317beeee6175fbc76f4bb"
+    },
+    "pkgconfig": {
+      "Package": "pkgconfig",
+      "Version": "2.0.3",
+      "Source": "Repository",
+      "Repository": "RSPM",
+      "Requirements": [
+        "utils"
+      ],
+      "Hash": "01f28d4278f15c76cddbea05899c5d6f"
+    },
+    "prettyunits": {
+      "Package": "prettyunits",
+      "Version": "1.1.1",
+      "Source": "Repository",
+      "Repository": "RSPM",
+      "Hash": "95ef9167b75dde9d2ccc3c7528393e7e"
+    },
+    "progress": {
+      "Package": "progress",
+      "Version": "1.2.2",
+      "Source": "Repository",
+      "Repository": "CRAN",
+      "Requirements": [
+        "R6",
+        "crayon",
+        "hms",
+        "prettyunits"
+      ],
+      "Hash": "14dc9f7a3c91ebb14ec5bb9208a07061"
+    },
+    "purrr": {
+      "Package": "purrr",
+      "Version": "1.0.1",
+      "Source": "Repository",
+      "Repository": "RSPM",
+      "Requirements": [
+        "R",
+        "cli",
+        "lifecycle",
+        "magrittr",
+        "rlang",
+        "vctrs"
+      ],
+      "Hash": "d71c815267c640f17ddbf7f16144b4bb"
+    },
+    "rappdirs": {
+      "Package": "rappdirs",
+      "Version": "0.3.3",
+      "Source": "Repository",
+      "Repository": "RSPM",
+      "Requirements": [
+        "R"
+      ],
+      "Hash": "5e3c5dc0b071b21fa128676560dbe94d"
+    },
+    "reactR": {
+      "Package": "reactR",
+      "Version": "0.4.4",
+      "Source": "Repository",
+      "Repository": "CRAN",
+      "Requirements": [
+        "htmltools"
+      ],
+      "Hash": "75389c8091eb14ee21c6bc87a88b3809"
+    },
+    "reactable": {
+      "Package": "reactable",
+      "Version": "0.4.4",
+      "Source": "Repository",
+      "Repository": "CRAN",
+      "Requirements": [
+        "R",
+        "digest",
+        "htmltools",
+        "htmlwidgets",
+        "jsonlite",
+        "reactR"
+      ],
+      "Hash": "6069eb2a6597963eae0605c1875ff14c"
+    },
+    "readr": {
+      "Package": "readr",
+      "Version": "2.1.4",
+      "Source": "Repository",
+      "Repository": "CRAN",
+      "Requirements": [
+        "R",
+        "R6",
+        "cli",
+        "clipr",
+        "cpp11",
+        "crayon",
+        "hms",
+        "lifecycle",
+        "methods",
+        "rlang",
+        "tibble",
+        "tzdb",
+        "utils",
+        "vroom"
+      ],
+      "Hash": "b5047343b3825f37ad9d3b5d89aa1078"
+    },
+    "renv": {
+      "Package": "renv",
+      "Version": "1.0.0",
+      "Source": "Repository",
+      "Repository": "CRAN",
+      "Requirements": [
+        "utils"
+      ],
+      "Hash": "c321cd99d56443dbffd1c9e673c0c1a2"
+    },
+    "rlang": {
+      "Package": "rlang",
+      "Version": "1.1.1",
+      "Source": "Repository",
+      "Repository": "RSPM",
+      "Requirements": [
+        "R",
+        "utils"
+      ],
+      "Hash": "a85c767b55f0bf9b7ad16c6d7baee5bb"
+    },
+    "rmarkdown": {
+      "Package": "rmarkdown",
+      "Version": "2.21",
+      "Source": "Repository",
+      "Repository": "RSPM",
+      "Requirements": [
+        "R",
+        "bslib",
+        "evaluate",
+        "fontawesome",
+        "htmltools",
+        "jquerylib",
+        "jsonlite",
+        "knitr",
+        "methods",
+        "stringr",
+        "tinytex",
+        "tools",
+        "utils",
+        "xfun",
+        "yaml"
+      ],
+      "Hash": "493df4ae51e2e984952ea4d5c75786a3"
+    },
+    "sass": {
+      "Package": "sass",
+      "Version": "0.4.6",
+      "Source": "Repository",
+      "Repository": "RSPM",
+      "Requirements": [
+        "R6",
+        "fs",
+        "htmltools",
+        "rappdirs",
+        "rlang"
+      ],
+      "Hash": "cc3ec7dd33982ef56570229b62d6388e"
+    },
+    "scales": {
+      "Package": "scales",
+      "Version": "1.2.1",
+      "Source": "Repository",
+      "Repository": "RSPM",
+      "Requirements": [
+        "R",
+        "R6",
+        "RColorBrewer",
+        "farver",
+        "labeling",
+        "lifecycle",
+        "munsell",
+        "rlang",
+        "viridisLite"
+      ],
+      "Hash": "906cb23d2f1c5680b8ce439b44c6fa63"
+    },
+    "stringi": {
+      "Package": "stringi",
+      "Version": "1.7.12",
+      "Source": "Repository",
+      "Repository": "RSPM",
+      "Requirements": [
+        "R",
+        "stats",
+        "tools",
+        "utils"
+      ],
+      "Hash": "ca8bd84263c77310739d2cf64d84d7c9"
+    },
+    "stringr": {
+      "Package": "stringr",
+      "Version": "1.5.0",
+      "Source": "Repository",
+      "Repository": "RSPM",
+      "Requirements": [
+        "R",
+        "cli",
+        "glue",
+        "lifecycle",
+        "magrittr",
+        "rlang",
+        "stringi",
+        "vctrs"
+      ],
+      "Hash": "671a4d384ae9d32fc47a14e98bfa3dc8"
+    },
+    "tibble": {
+      "Package": "tibble",
+      "Version": "3.2.1",
+      "Source": "Repository",
+      "Repository": "RSPM",
+      "Requirements": [
+        "R",
+        "fansi",
+        "lifecycle",
+        "magrittr",
+        "methods",
+        "pillar",
+        "pkgconfig",
+        "rlang",
+        "utils",
+        "vctrs"
+      ],
+      "Hash": "a84e2cc86d07289b3b6f5069df7a004c"
+    },
+    "tidyr": {
+      "Package": "tidyr",
+      "Version": "1.3.0",
+      "Source": "Repository",
+      "Repository": "RSPM",
+      "Requirements": [
+        "R",
+        "cli",
+        "cpp11",
+        "dplyr",
+        "glue",
+        "lifecycle",
+        "magrittr",
+        "purrr",
+        "rlang",
+        "stringr",
+        "tibble",
+        "tidyselect",
+        "utils",
+        "vctrs"
+      ],
+      "Hash": "e47debdc7ce599b070c8e78e8ac0cfcf"
+    },
+    "tidyselect": {
+      "Package": "tidyselect",
+      "Version": "1.2.0",
+      "Source": "Repository",
+      "Repository": "RSPM",
+      "Requirements": [
+        "R",
+        "cli",
+        "glue",
+        "lifecycle",
+        "rlang",
+        "vctrs",
+        "withr"
+      ],
+      "Hash": "79540e5fcd9e0435af547d885f184fd5"
+    },
+    "timechange": {
+      "Package": "timechange",
+      "Version": "0.2.0",
+      "Source": "Repository",
+      "Repository": "CRAN",
+      "Requirements": [
+        "R",
+        "cpp11"
+      ],
+      "Hash": "8548b44f79a35ba1791308b61e6012d7"
+    },
+    "tinytex": {
+      "Package": "tinytex",
+      "Version": "0.45",
+      "Source": "Repository",
+      "Repository": "RSPM",
+      "Requirements": [
+        "xfun"
+      ],
+      "Hash": "e4e357f28c2edff493936b6cb30c3d65"
+    },
+    "tzdb": {
+      "Package": "tzdb",
+      "Version": "0.4.0",
+      "Source": "Repository",
+      "Repository": "CRAN",
+      "Requirements": [
+        "R",
+        "cpp11"
+      ],
+      "Hash": "f561504ec2897f4d46f0c7657e488ae1"
+    },
+    "utf8": {
+      "Package": "utf8",
+      "Version": "1.2.3",
+      "Source": "Repository",
+      "Repository": "RSPM",
+      "Requirements": [
+        "R"
+      ],
+      "Hash": "1fe17157424bb09c48a8b3b550c753bc"
+    },
+    "vctrs": {
+      "Package": "vctrs",
+      "Version": "0.6.2",
+      "Source": "Repository",
+      "Repository": "RSPM",
+      "Requirements": [
+        "R",
+        "cli",
+        "glue",
+        "lifecycle",
+        "rlang"
+      ],
+      "Hash": "a745bda7aff4734c17294bb41d4e4607"
+    },
+    "viridisLite": {
+      "Package": "viridisLite",
+      "Version": "0.4.2",
+      "Source": "Repository",
+      "Repository": "RSPM",
+      "Requirements": [
+        "R"
+      ],
+      "Hash": "c826c7c4241b6fc89ff55aaea3fa7491"
+    },
+    "vroom": {
+      "Package": "vroom",
+      "Version": "1.6.3",
+      "Source": "Repository",
+      "Repository": "CRAN",
+      "Requirements": [
+        "R",
+        "bit64",
+        "cli",
+        "cpp11",
+        "crayon",
+        "glue",
+        "hms",
+        "lifecycle",
+        "methods",
+        "progress",
+        "rlang",
+        "stats",
+        "tibble",
+        "tidyselect",
+        "tzdb",
+        "vctrs",
+        "withr"
+      ],
+      "Hash": "8318e64ffb3a70e652494017ec455561"
+    },
+    "withr": {
+      "Package": "withr",
+      "Version": "2.5.0",
+      "Source": "Repository",
+      "Repository": "RSPM",
+      "Requirements": [
+        "R",
+        "grDevices",
+        "graphics",
+        "stats"
+      ],
+      "Hash": "c0e49a9760983e81e55cdd9be92e7182"
+    },
+    "xfun": {
+      "Package": "xfun",
+      "Version": "0.39",
+      "Source": "Repository",
+      "Repository": "RSPM",
+      "Requirements": [
+        "stats",
+        "tools"
+      ],
+      "Hash": "8f56e9acb54fb525e66464d57ab58bcb"
+    },
+    "xml2": {
+      "Package": "xml2",
+      "Version": "1.3.4",
+      "Source": "Repository",
+      "Repository": "CRAN",
+      "Requirements": [
+        "R",
+        "methods"
+      ],
+      "Hash": "7dc765ac9b909487326a7d471fdd3821"
+    },
+    "yaml": {
+      "Package": "yaml",
+      "Version": "2.3.7",
+      "Source": "Repository",
+      "Repository": "RSPM",
+      "Hash": "0d0056cc5383fbc240ccd0cb584bf436"
+    }
+  }
+}

--- a/crossbow-nightly-report/renv/.gitignore
+++ b/crossbow-nightly-report/renv/.gitignore
@@ -1,0 +1,7 @@
+library/
+local/
+cellar/
+lock/
+python/
+sandbox/
+staging/

--- a/crossbow-nightly-report/renv/activate.R
+++ b/crossbow-nightly-report/renv/activate.R
@@ -1,0 +1,1181 @@
+
+local({
+
+  # the requested version of renv
+  version <- "1.0.0"
+  attr(version, "sha") <- NULL
+
+  # the project directory
+  project <- getwd()
+
+  # figure out whether the autoloader is enabled
+  enabled <- local({
+
+    # first, check config option
+    override <- getOption("renv.config.autoloader.enabled")
+    if (!is.null(override))
+      return(override)
+
+    # next, check environment variables
+    # TODO: prefer using the configuration one in the future
+    envvars <- c(
+      "RENV_CONFIG_AUTOLOADER_ENABLED",
+      "RENV_AUTOLOADER_ENABLED",
+      "RENV_ACTIVATE_PROJECT"
+    )
+
+    for (envvar in envvars) {
+      envval <- Sys.getenv(envvar, unset = NA)
+      if (!is.na(envval))
+        return(tolower(envval) %in% c("true", "t", "1"))
+    }
+
+    # enable by default
+    TRUE
+
+  })
+
+  if (!enabled)
+    return(FALSE)
+
+  # avoid recursion
+  if (identical(getOption("renv.autoloader.running"), TRUE)) {
+    warning("ignoring recursive attempt to run renv autoloader")
+    return(invisible(TRUE))
+  }
+
+  # signal that we're loading renv during R startup
+  options(renv.autoloader.running = TRUE)
+  on.exit(options(renv.autoloader.running = NULL), add = TRUE)
+
+  # signal that we've consented to use renv
+  options(renv.consent = TRUE)
+
+  # load the 'utils' package eagerly -- this ensures that renv shims, which
+  # mask 'utils' packages, will come first on the search path
+  library(utils, lib.loc = .Library)
+
+  # unload renv if it's already been loaded
+  if ("renv" %in% loadedNamespaces())
+    unloadNamespace("renv")
+
+  # load bootstrap tools   
+  `%||%` <- function(x, y) {
+    if (is.null(x)) y else x
+  }
+  
+  catf <- function(fmt, ..., appendLF = TRUE) {
+  
+    quiet <- getOption("renv.bootstrap.quiet", default = FALSE)
+    if (quiet)
+      return(invisible())
+  
+    msg <- sprintf(fmt, ...)
+    cat(msg, file = stdout(), sep = if (appendLF) "\n" else "")
+  
+    invisible(msg)
+  
+  }
+  
+  header <- function(label,
+                     ...,
+                     prefix = "#",
+                     suffix = "-",
+                     n = min(getOption("width"), 78))
+  {
+    label <- sprintf(label, ...)
+    n <- max(n - nchar(label) - nchar(prefix) - 2L, 8L)
+    if (n <= 0)
+      return(paste(prefix, label))
+  
+    tail <- paste(rep.int(suffix, n), collapse = "")
+    paste0(prefix, " ", label, " ", tail)
+  
+  }
+  
+  startswith <- function(string, prefix) {
+    substring(string, 1, nchar(prefix)) == prefix
+  }
+  
+  bootstrap <- function(version, library) {
+  
+    friendly <- renv_bootstrap_version_friendly(version)
+    section <- header(sprintf("Bootstrapping renv %s", friendly))
+    catf(section)
+  
+    # attempt to download renv
+    catf("- Downloading renv ... ", appendLF = FALSE)
+    withCallingHandlers(
+      tarball <- renv_bootstrap_download(version),
+      error = function(err) {
+        catf("FAILED")
+        stop("failed to download:\n", conditionMessage(err))
+      }
+    )
+    catf("OK")
+    on.exit(unlink(tarball), add = TRUE)
+  
+    # now attempt to install
+    catf("- Installing renv  ... ", appendLF = FALSE)
+    withCallingHandlers(
+      status <- renv_bootstrap_install(version, tarball, library),
+      error = function(err) {
+        catf("FAILED")
+        stop("failed to install:\n", conditionMessage(err))
+      }
+    )
+    catf("OK")
+  
+    # add empty line to break up bootstrapping from normal output
+    catf("")
+  
+    return(invisible())
+  }
+  
+  renv_bootstrap_tests_running <- function() {
+    getOption("renv.tests.running", default = FALSE)
+  }
+  
+  renv_bootstrap_repos <- function() {
+  
+    # get CRAN repository
+    cran <- getOption("renv.repos.cran", "https://cloud.r-project.org")
+  
+    # check for repos override
+    repos <- Sys.getenv("RENV_CONFIG_REPOS_OVERRIDE", unset = NA)
+    if (!is.na(repos)) {
+  
+      # check for RSPM; if set, use a fallback repository for renv
+      rspm <- Sys.getenv("RSPM", unset = NA)
+      if (identical(rspm, repos))
+        repos <- c(RSPM = rspm, CRAN = cran)
+  
+      return(repos)
+  
+    }
+  
+    # check for lockfile repositories
+    repos <- tryCatch(renv_bootstrap_repos_lockfile(), error = identity)
+    if (!inherits(repos, "error") && length(repos))
+      return(repos)
+  
+    # retrieve current repos
+    repos <- getOption("repos")
+  
+    # ensure @CRAN@ entries are resolved
+    repos[repos == "@CRAN@"] <- cran
+  
+    # add in renv.bootstrap.repos if set
+    default <- c(FALLBACK = "https://cloud.r-project.org")
+    extra <- getOption("renv.bootstrap.repos", default = default)
+    repos <- c(repos, extra)
+  
+    # remove duplicates that might've snuck in
+    dupes <- duplicated(repos) | duplicated(names(repos))
+    repos[!dupes]
+  
+  }
+  
+  renv_bootstrap_repos_lockfile <- function() {
+  
+    lockpath <- Sys.getenv("RENV_PATHS_LOCKFILE", unset = "renv.lock")
+    if (!file.exists(lockpath))
+      return(NULL)
+  
+    lockfile <- tryCatch(renv_json_read(lockpath), error = identity)
+    if (inherits(lockfile, "error")) {
+      warning(lockfile)
+      return(NULL)
+    }
+  
+    repos <- lockfile$R$Repositories
+    if (length(repos) == 0)
+      return(NULL)
+  
+    keys <- vapply(repos, `[[`, "Name", FUN.VALUE = character(1))
+    vals <- vapply(repos, `[[`, "URL", FUN.VALUE = character(1))
+    names(vals) <- keys
+  
+    return(vals)
+  
+  }
+  
+  renv_bootstrap_download <- function(version) {
+  
+    sha <- attr(version, "sha", exact = TRUE)
+  
+    methods <- if (!is.null(sha)) {
+  
+      # attempting to bootstrap a development version of renv
+      c(
+        function() renv_bootstrap_download_tarball(sha),
+        function() renv_bootstrap_download_github(sha)
+      )
+  
+    } else {
+  
+      # attempting to bootstrap a release version of renv
+      c(
+        function() renv_bootstrap_download_tarball(version),
+        function() renv_bootstrap_download_cran_latest(version),
+        function() renv_bootstrap_download_cran_archive(version)
+      )
+  
+    }
+  
+    for (method in methods) {
+      path <- tryCatch(method(), error = identity)
+      if (is.character(path) && file.exists(path))
+        return(path)
+    }
+  
+    stop("All download methods failed")
+  
+  }
+  
+  renv_bootstrap_download_impl <- function(url, destfile) {
+  
+    mode <- "wb"
+  
+    # https://bugs.r-project.org/bugzilla/show_bug.cgi?id=17715
+    fixup <-
+      Sys.info()[["sysname"]] == "Windows" &&
+      substring(url, 1L, 5L) == "file:"
+  
+    if (fixup)
+      mode <- "w+b"
+  
+    args <- list(
+      url      = url,
+      destfile = destfile,
+      mode     = mode,
+      quiet    = TRUE
+    )
+  
+    if ("headers" %in% names(formals(utils::download.file)))
+      args$headers <- renv_bootstrap_download_custom_headers(url)
+  
+    do.call(utils::download.file, args)
+  
+  }
+  
+  renv_bootstrap_download_custom_headers <- function(url) {
+  
+    headers <- getOption("renv.download.headers")
+    if (is.null(headers))
+      return(character())
+  
+    if (!is.function(headers))
+      stopf("'renv.download.headers' is not a function")
+  
+    headers <- headers(url)
+    if (length(headers) == 0L)
+      return(character())
+  
+    if (is.list(headers))
+      headers <- unlist(headers, recursive = FALSE, use.names = TRUE)
+  
+    ok <-
+      is.character(headers) &&
+      is.character(names(headers)) &&
+      all(nzchar(names(headers)))
+  
+    if (!ok)
+      stop("invocation of 'renv.download.headers' did not return a named character vector")
+  
+    headers
+  
+  }
+  
+  renv_bootstrap_download_cran_latest <- function(version) {
+  
+    spec <- renv_bootstrap_download_cran_latest_find(version)
+    type  <- spec$type
+    repos <- spec$repos
+  
+    baseurl <- utils::contrib.url(repos = repos, type = type)
+    ext <- if (identical(type, "source"))
+      ".tar.gz"
+    else if (Sys.info()[["sysname"]] == "Windows")
+      ".zip"
+    else
+      ".tgz"
+    name <- sprintf("renv_%s%s", version, ext)
+    url <- paste(baseurl, name, sep = "/")
+  
+    destfile <- file.path(tempdir(), name)
+    status <- tryCatch(
+      renv_bootstrap_download_impl(url, destfile),
+      condition = identity
+    )
+  
+    if (inherits(status, "condition"))
+      return(FALSE)
+  
+    # report success and return
+    destfile
+  
+  }
+  
+  renv_bootstrap_download_cran_latest_find <- function(version) {
+  
+    # check whether binaries are supported on this system
+    binary <-
+      getOption("renv.bootstrap.binary", default = TRUE) &&
+      !identical(.Platform$pkgType, "source") &&
+      !identical(getOption("pkgType"), "source") &&
+      Sys.info()[["sysname"]] %in% c("Darwin", "Windows")
+  
+    types <- c(if (binary) "binary", "source")
+  
+    # iterate over types + repositories
+    for (type in types) {
+      for (repos in renv_bootstrap_repos()) {
+  
+        # retrieve package database
+        db <- tryCatch(
+          as.data.frame(
+            utils::available.packages(type = type, repos = repos),
+            stringsAsFactors = FALSE
+          ),
+          error = identity
+        )
+  
+        if (inherits(db, "error"))
+          next
+  
+        # check for compatible entry
+        entry <- db[db$Package %in% "renv" & db$Version %in% version, ]
+        if (nrow(entry) == 0)
+          next
+  
+        # found it; return spec to caller
+        spec <- list(entry = entry, type = type, repos = repos)
+        return(spec)
+  
+      }
+    }
+  
+    # if we got here, we failed to find renv
+    fmt <- "renv %s is not available from your declared package repositories"
+    stop(sprintf(fmt, version))
+  
+  }
+  
+  renv_bootstrap_download_cran_archive <- function(version) {
+  
+    name <- sprintf("renv_%s.tar.gz", version)
+    repos <- renv_bootstrap_repos()
+    urls <- file.path(repos, "src/contrib/Archive/renv", name)
+    destfile <- file.path(tempdir(), name)
+  
+    for (url in urls) {
+  
+      status <- tryCatch(
+        renv_bootstrap_download_impl(url, destfile),
+        condition = identity
+      )
+  
+      if (identical(status, 0L))
+        return(destfile)
+  
+    }
+  
+    return(FALSE)
+  
+  }
+  
+  renv_bootstrap_download_tarball <- function(version) {
+  
+    # if the user has provided the path to a tarball via
+    # an environment variable, then use it
+    tarball <- Sys.getenv("RENV_BOOTSTRAP_TARBALL", unset = NA)
+    if (is.na(tarball))
+      return()
+  
+    # allow directories
+    if (dir.exists(tarball)) {
+      name <- sprintf("renv_%s.tar.gz", version)
+      tarball <- file.path(tarball, name)
+    }
+  
+    # bail if it doesn't exist
+    if (!file.exists(tarball)) {
+  
+      # let the user know we weren't able to honour their request
+      fmt <- "- RENV_BOOTSTRAP_TARBALL is set (%s) but does not exist."
+      msg <- sprintf(fmt, tarball)
+      warning(msg)
+  
+      # bail
+      return()
+  
+    }
+  
+    catf("- Using local tarball '%s'.", tarball)
+    tarball
+  
+  }
+  
+  renv_bootstrap_download_github <- function(version) {
+  
+    enabled <- Sys.getenv("RENV_BOOTSTRAP_FROM_GITHUB", unset = "TRUE")
+    if (!identical(enabled, "TRUE"))
+      return(FALSE)
+  
+    # prepare download options
+    pat <- Sys.getenv("GITHUB_PAT")
+    if (nzchar(Sys.which("curl")) && nzchar(pat)) {
+      fmt <- "--location --fail --header \"Authorization: token %s\""
+      extra <- sprintf(fmt, pat)
+      saved <- options("download.file.method", "download.file.extra")
+      options(download.file.method = "curl", download.file.extra = extra)
+      on.exit(do.call(base::options, saved), add = TRUE)
+    } else if (nzchar(Sys.which("wget")) && nzchar(pat)) {
+      fmt <- "--header=\"Authorization: token %s\""
+      extra <- sprintf(fmt, pat)
+      saved <- options("download.file.method", "download.file.extra")
+      options(download.file.method = "wget", download.file.extra = extra)
+      on.exit(do.call(base::options, saved), add = TRUE)
+    }
+  
+    url <- file.path("https://api.github.com/repos/rstudio/renv/tarball", version)
+    name <- sprintf("renv_%s.tar.gz", version)
+    destfile <- file.path(tempdir(), name)
+  
+    status <- tryCatch(
+      renv_bootstrap_download_impl(url, destfile),
+      condition = identity
+    )
+  
+    if (!identical(status, 0L))
+      return(FALSE)
+  
+    renv_bootstrap_download_augment(destfile)
+  
+    return(destfile)
+  
+  }
+  
+  # Add Sha to DESCRIPTION. This is stop gap until #890, after which we
+  # can use renv::install() to fully capture metadata.
+  renv_bootstrap_download_augment <- function(destfile) {
+    sha <- renv_bootstrap_git_extract_sha1_tar(destfile)
+    if (is.null(sha)) {
+      return()
+    }
+  
+    # Untar
+    tempdir <- tempfile("renv-github-")
+    on.exit(unlink(tempdir, recursive = TRUE), add = TRUE)
+    untar(destfile, exdir = tempdir)
+    pkgdir <- dir(tempdir, full.names = TRUE)[[1]]
+  
+    # Modify description
+    desc_path <- file.path(pkgdir, "DESCRIPTION")
+    desc_lines <- readLines(desc_path)
+    remotes_fields <- c(
+      "RemoteType: github",
+      "RemoteHost: api.github.com",
+      "RemoteRepo: renv",
+      "RemoteUsername: rstudio",
+      "RemotePkgRef: rstudio/renv",
+      paste("RemoteRef: ", sha),
+      paste("RemoteSha: ", sha)
+    )
+    writeLines(c(desc_lines[desc_lines != ""], remotes_fields), con = desc_path)
+  
+    # Re-tar
+    local({
+      old <- setwd(tempdir)
+      on.exit(setwd(old), add = TRUE)
+  
+      tar(destfile, compression = "gzip")
+    })
+    invisible()
+  }
+  
+  # Extract the commit hash from a git archive. Git archives include the SHA1
+  # hash as the comment field of the tarball pax extended header
+  # (see https://www.kernel.org/pub/software/scm/git/docs/git-archive.html)
+  # For GitHub archives this should be the first header after the default one
+  # (512 byte) header.
+  renv_bootstrap_git_extract_sha1_tar <- function(bundle) {
+  
+    # open the bundle for reading
+    # We use gzcon for everything because (from ?gzcon)
+    # > Reading from a connection which does not supply a ‘gzip’ magic
+    # > header is equivalent to reading from the original connection
+    conn <- gzcon(file(bundle, open = "rb", raw = TRUE))
+    on.exit(close(conn))
+  
+    # The default pax header is 512 bytes long and the first pax extended header
+    # with the comment should be 51 bytes long
+    # `52 comment=` (11 chars) + 40 byte SHA1 hash
+    len <- 0x200 + 0x33
+    res <- rawToChar(readBin(conn, "raw", n = len)[0x201:len])
+  
+    if (grepl("^52 comment=", res)) {
+      sub("52 comment=", "", res)
+    } else {
+      NULL
+    }
+  }
+  
+  renv_bootstrap_install <- function(version, tarball, library) {
+  
+    # attempt to install it into project library
+    dir.create(library, showWarnings = FALSE, recursive = TRUE)
+    output <- renv_bootstrap_install_impl(library, tarball)
+  
+    # check for successful install
+    status <- attr(output, "status")
+    if (is.null(status) || identical(status, 0L))
+      return(status)
+  
+    # an error occurred; report it
+    header <- "installation of renv failed"
+    lines <- paste(rep.int("=", nchar(header)), collapse = "")
+    text <- paste(c(header, lines, output), collapse = "\n")
+    stop(text)
+  
+  }
+  
+  renv_bootstrap_install_impl <- function(library, tarball) {
+  
+    # invoke using system2 so we can capture and report output
+    bin <- R.home("bin")
+    exe <- if (Sys.info()[["sysname"]] == "Windows") "R.exe" else "R"
+    R <- file.path(bin, exe)
+  
+    args <- c(
+      "--vanilla", "CMD", "INSTALL", "--no-multiarch",
+      "-l", shQuote(path.expand(library)),
+      shQuote(path.expand(tarball))
+    )
+  
+    system2(R, args, stdout = TRUE, stderr = TRUE)
+  
+  }
+  
+  renv_bootstrap_platform_prefix <- function() {
+  
+    # construct version prefix
+    version <- paste(R.version$major, R.version$minor, sep = ".")
+    prefix <- paste("R", numeric_version(version)[1, 1:2], sep = "-")
+  
+    # include SVN revision for development versions of R
+    # (to avoid sharing platform-specific artefacts with released versions of R)
+    devel <-
+      identical(R.version[["status"]],   "Under development (unstable)") ||
+      identical(R.version[["nickname"]], "Unsuffered Consequences")
+  
+    if (devel)
+      prefix <- paste(prefix, R.version[["svn rev"]], sep = "-r")
+  
+    # build list of path components
+    components <- c(prefix, R.version$platform)
+  
+    # include prefix if provided by user
+    prefix <- renv_bootstrap_platform_prefix_impl()
+    if (!is.na(prefix) && nzchar(prefix))
+      components <- c(prefix, components)
+  
+    # build prefix
+    paste(components, collapse = "/")
+  
+  }
+  
+  renv_bootstrap_platform_prefix_impl <- function() {
+  
+    # if an explicit prefix has been supplied, use it
+    prefix <- Sys.getenv("RENV_PATHS_PREFIX", unset = NA)
+    if (!is.na(prefix))
+      return(prefix)
+  
+    # if the user has requested an automatic prefix, generate it
+    auto <- Sys.getenv("RENV_PATHS_PREFIX_AUTO", unset = NA)
+    if (auto %in% c("TRUE", "True", "true", "1"))
+      return(renv_bootstrap_platform_prefix_auto())
+  
+    # empty string on failure
+    ""
+  
+  }
+  
+  renv_bootstrap_platform_prefix_auto <- function() {
+  
+    prefix <- tryCatch(renv_bootstrap_platform_os(), error = identity)
+    if (inherits(prefix, "error") || prefix %in% "unknown") {
+  
+      msg <- paste(
+        "failed to infer current operating system",
+        "please file a bug report at https://github.com/rstudio/renv/issues",
+        sep = "; "
+      )
+  
+      warning(msg)
+  
+    }
+  
+    prefix
+  
+  }
+  
+  renv_bootstrap_platform_os <- function() {
+  
+    sysinfo <- Sys.info()
+    sysname <- sysinfo[["sysname"]]
+  
+    # handle Windows + macOS up front
+    if (sysname == "Windows")
+      return("windows")
+    else if (sysname == "Darwin")
+      return("macos")
+  
+    # check for os-release files
+    for (file in c("/etc/os-release", "/usr/lib/os-release"))
+      if (file.exists(file))
+        return(renv_bootstrap_platform_os_via_os_release(file, sysinfo))
+  
+    # check for redhat-release files
+    if (file.exists("/etc/redhat-release"))
+      return(renv_bootstrap_platform_os_via_redhat_release())
+  
+    "unknown"
+  
+  }
+  
+  renv_bootstrap_platform_os_via_os_release <- function(file, sysinfo) {
+  
+    # read /etc/os-release
+    release <- utils::read.table(
+      file             = file,
+      sep              = "=",
+      quote            = c("\"", "'"),
+      col.names        = c("Key", "Value"),
+      comment.char     = "#",
+      stringsAsFactors = FALSE
+    )
+  
+    vars <- as.list(release$Value)
+    names(vars) <- release$Key
+  
+    # get os name
+    os <- tolower(sysinfo[["sysname"]])
+  
+    # read id
+    id <- "unknown"
+    for (field in c("ID", "ID_LIKE")) {
+      if (field %in% names(vars) && nzchar(vars[[field]])) {
+        id <- vars[[field]]
+        break
+      }
+    }
+  
+    # read version
+    version <- "unknown"
+    for (field in c("UBUNTU_CODENAME", "VERSION_CODENAME", "VERSION_ID", "BUILD_ID")) {
+      if (field %in% names(vars) && nzchar(vars[[field]])) {
+        version <- vars[[field]]
+        break
+      }
+    }
+  
+    # join together
+    paste(c(os, id, version), collapse = "-")
+  
+  }
+  
+  renv_bootstrap_platform_os_via_redhat_release <- function() {
+  
+    # read /etc/redhat-release
+    contents <- readLines("/etc/redhat-release", warn = FALSE)
+  
+    # infer id
+    id <- if (grepl("centos", contents, ignore.case = TRUE))
+      "centos"
+    else if (grepl("redhat", contents, ignore.case = TRUE))
+      "redhat"
+    else
+      "unknown"
+  
+    # try to find a version component (very hacky)
+    version <- "unknown"
+  
+    parts <- strsplit(contents, "[[:space:]]")[[1L]]
+    for (part in parts) {
+  
+      nv <- tryCatch(numeric_version(part), error = identity)
+      if (inherits(nv, "error"))
+        next
+  
+      version <- nv[1, 1]
+      break
+  
+    }
+  
+    paste(c("linux", id, version), collapse = "-")
+  
+  }
+  
+  renv_bootstrap_library_root_name <- function(project) {
+  
+    # use project name as-is if requested
+    asis <- Sys.getenv("RENV_PATHS_LIBRARY_ROOT_ASIS", unset = "FALSE")
+    if (asis)
+      return(basename(project))
+  
+    # otherwise, disambiguate based on project's path
+    id <- substring(renv_bootstrap_hash_text(project), 1L, 8L)
+    paste(basename(project), id, sep = "-")
+  
+  }
+  
+  renv_bootstrap_library_root <- function(project) {
+  
+    prefix <- renv_bootstrap_profile_prefix()
+  
+    path <- Sys.getenv("RENV_PATHS_LIBRARY", unset = NA)
+    if (!is.na(path))
+      return(paste(c(path, prefix), collapse = "/"))
+  
+    path <- renv_bootstrap_library_root_impl(project)
+    if (!is.null(path)) {
+      name <- renv_bootstrap_library_root_name(project)
+      return(paste(c(path, prefix, name), collapse = "/"))
+    }
+  
+    renv_bootstrap_paths_renv("library", project = project)
+  
+  }
+  
+  renv_bootstrap_library_root_impl <- function(project) {
+  
+    root <- Sys.getenv("RENV_PATHS_LIBRARY_ROOT", unset = NA)
+    if (!is.na(root))
+      return(root)
+  
+    type <- renv_bootstrap_project_type(project)
+    if (identical(type, "package")) {
+      userdir <- renv_bootstrap_user_dir()
+      return(file.path(userdir, "library"))
+    }
+  
+  }
+  
+  renv_bootstrap_validate_version <- function(version, description = NULL) {
+  
+    # resolve description file
+    description <- description %||% {
+      path <- getNamespaceInfo("renv", "path")
+      packageDescription("renv", lib.loc = dirname(path))
+    }
+  
+    # check whether requested version 'version' matches loaded version of renv
+    sha <- attr(version, "sha", exact = TRUE)
+    valid <- if (!is.null(sha))
+      renv_bootstrap_validate_version_dev(sha, description)
+    else
+      renv_bootstrap_validate_version_release(version, description)
+  
+    if (valid)
+      return(TRUE)
+  
+    # the loaded version of renv doesn't match the requested version;
+    # give the user instructions on how to proceed
+    remote <- if (!is.null(description[["RemoteSha"]])) {
+      paste("rstudio/renv", description[["RemoteSha"]], sep = "@")
+    } else {
+      paste("renv", description[["Version"]], sep = "@")
+    }
+  
+    # display both loaded version + sha if available
+    friendly <- renv_bootstrap_version_friendly(
+      version = description[["Version"]],
+      sha     = description[["RemoteSha"]]
+    )
+  
+    fmt <- paste(
+      "renv %1$s was loaded from project library, but this project is configured to use renv %2$s.",
+      "- Use `renv::record(\"%3$s\")` to record renv %1$s in the lockfile.",
+      "- Use `renv::restore(packages = \"renv\")` to install renv %2$s into the project library.",
+      sep = "\n"
+    )
+    catf(fmt, friendly, renv_bootstrap_version_friendly(version), remote)
+  
+    FALSE
+  
+  }
+  
+  renv_bootstrap_validate_version_dev <- function(version, description) {
+    expected <- description[["RemoteSha"]]
+    is.character(expected) && startswith(expected, version)
+  }
+  
+  renv_bootstrap_validate_version_release <- function(version, description) {
+    expected <- description[["Version"]]
+    is.character(expected) && identical(expected, version)
+  }
+  
+  renv_bootstrap_hash_text <- function(text) {
+  
+    hashfile <- tempfile("renv-hash-")
+    on.exit(unlink(hashfile), add = TRUE)
+  
+    writeLines(text, con = hashfile)
+    tools::md5sum(hashfile)
+  
+  }
+  
+  renv_bootstrap_load <- function(project, libpath, version) {
+  
+    # try to load renv from the project library
+    if (!requireNamespace("renv", lib.loc = libpath, quietly = TRUE))
+      return(FALSE)
+  
+    # warn if the version of renv loaded does not match
+    renv_bootstrap_validate_version(version)
+  
+    # execute renv load hooks, if any
+    hooks <- getHook("renv::autoload")
+    for (hook in hooks)
+      if (is.function(hook))
+        tryCatch(hook(), error = warning)
+  
+    # load the project
+    renv::load(project)
+  
+    TRUE
+  
+  }
+  
+  renv_bootstrap_profile_load <- function(project) {
+  
+    # if RENV_PROFILE is already set, just use that
+    profile <- Sys.getenv("RENV_PROFILE", unset = NA)
+    if (!is.na(profile) && nzchar(profile))
+      return(profile)
+  
+    # check for a profile file (nothing to do if it doesn't exist)
+    path <- renv_bootstrap_paths_renv("profile", profile = FALSE, project = project)
+    if (!file.exists(path))
+      return(NULL)
+  
+    # read the profile, and set it if it exists
+    contents <- readLines(path, warn = FALSE)
+    if (length(contents) == 0L)
+      return(NULL)
+  
+    # set RENV_PROFILE
+    profile <- contents[[1L]]
+    if (!profile %in% c("", "default"))
+      Sys.setenv(RENV_PROFILE = profile)
+  
+    profile
+  
+  }
+  
+  renv_bootstrap_profile_prefix <- function() {
+    profile <- renv_bootstrap_profile_get()
+    if (!is.null(profile))
+      return(file.path("profiles", profile, "renv"))
+  }
+  
+  renv_bootstrap_profile_get <- function() {
+    profile <- Sys.getenv("RENV_PROFILE", unset = "")
+    renv_bootstrap_profile_normalize(profile)
+  }
+  
+  renv_bootstrap_profile_set <- function(profile) {
+    profile <- renv_bootstrap_profile_normalize(profile)
+    if (is.null(profile))
+      Sys.unsetenv("RENV_PROFILE")
+    else
+      Sys.setenv(RENV_PROFILE = profile)
+  }
+  
+  renv_bootstrap_profile_normalize <- function(profile) {
+  
+    if (is.null(profile) || profile %in% c("", "default"))
+      return(NULL)
+  
+    profile
+  
+  }
+  
+  renv_bootstrap_path_absolute <- function(path) {
+  
+    substr(path, 1L, 1L) %in% c("~", "/", "\\") || (
+      substr(path, 1L, 1L) %in% c(letters, LETTERS) &&
+      substr(path, 2L, 3L) %in% c(":/", ":\\")
+    )
+  
+  }
+  
+  renv_bootstrap_paths_renv <- function(..., profile = TRUE, project = NULL) {
+    renv <- Sys.getenv("RENV_PATHS_RENV", unset = "renv")
+    root <- if (renv_bootstrap_path_absolute(renv)) NULL else project
+    prefix <- if (profile) renv_bootstrap_profile_prefix()
+    components <- c(root, renv, prefix, ...)
+    paste(components, collapse = "/")
+  }
+  
+  renv_bootstrap_project_type <- function(path) {
+  
+    descpath <- file.path(path, "DESCRIPTION")
+    if (!file.exists(descpath))
+      return("unknown")
+  
+    desc <- tryCatch(
+      read.dcf(descpath, all = TRUE),
+      error = identity
+    )
+  
+    if (inherits(desc, "error"))
+      return("unknown")
+  
+    type <- desc$Type
+    if (!is.null(type))
+      return(tolower(type))
+  
+    package <- desc$Package
+    if (!is.null(package))
+      return("package")
+  
+    "unknown"
+  
+  }
+  
+  renv_bootstrap_user_dir <- function() {
+    dir <- renv_bootstrap_user_dir_impl()
+    path.expand(chartr("\\", "/", dir))
+  }
+  
+  renv_bootstrap_user_dir_impl <- function() {
+  
+    # use local override if set
+    override <- getOption("renv.userdir.override")
+    if (!is.null(override))
+      return(override)
+  
+    # use R_user_dir if available
+    tools <- asNamespace("tools")
+    if (is.function(tools$R_user_dir))
+      return(tools$R_user_dir("renv", "cache"))
+  
+    # try using our own backfill for older versions of R
+    envvars <- c("R_USER_CACHE_DIR", "XDG_CACHE_HOME")
+    for (envvar in envvars) {
+      root <- Sys.getenv(envvar, unset = NA)
+      if (!is.na(root))
+        return(file.path(root, "R/renv"))
+    }
+  
+    # use platform-specific default fallbacks
+    if (Sys.info()[["sysname"]] == "Windows")
+      file.path(Sys.getenv("LOCALAPPDATA"), "R/cache/R/renv")
+    else if (Sys.info()[["sysname"]] == "Darwin")
+      "~/Library/Caches/org.R-project.R/R/renv"
+    else
+      "~/.cache/R/renv"
+  
+  }
+  
+  renv_bootstrap_version_friendly <- function(version, sha = NULL) {
+    sha <- sha %||% attr(version, "sha", exact = TRUE)
+    parts <- c(version, sprintf("[sha: %s]", substring(sha, 1L, 7L)))
+    paste(parts, collapse = " ")
+  }
+  
+  renv_bootstrap_run <- function(version, libpath) {
+  
+    # perform bootstrap
+    bootstrap(version, libpath)
+  
+    # exit early if we're just testing bootstrap
+    if (!is.na(Sys.getenv("RENV_BOOTSTRAP_INSTALL_ONLY", unset = NA)))
+      return(TRUE)
+  
+    # try again to load
+    if (requireNamespace("renv", lib.loc = libpath, quietly = TRUE)) {
+      return(renv::load(project = getwd()))
+    }
+  
+    # failed to download or load renv; warn the user
+    msg <- c(
+      "Failed to find an renv installation: the project will not be loaded.",
+      "Use `renv::activate()` to re-initialize the project."
+    )
+  
+    warning(paste(msg, collapse = "\n"), call. = FALSE)
+  
+  }
+  
+  
+  renv_bootstrap_in_rstudio <- function() {
+    commandArgs()[[1]] == "RStudio"
+  }
+  
+  renv_json_read <- function(file = NULL, text = NULL) {
+  
+    jlerr <- NULL
+  
+    # if jsonlite is loaded, use that instead
+    if ("jsonlite" %in% loadedNamespaces()) {
+  
+      json <- catch(renv_json_read_jsonlite(file, text))
+      if (!inherits(json, "error"))
+        return(json)
+  
+      jlerr <- json
+  
+    }
+  
+    # otherwise, fall back to the default JSON reader
+    json <- catch(renv_json_read_default(file, text))
+    if (!inherits(json, "error"))
+      return(json)
+  
+    # report an error
+    if (!is.null(jlerr))
+      stop(jlerr)
+    else
+      stop(json)
+  
+  }
+  
+  renv_json_read_jsonlite <- function(file = NULL, text = NULL) {
+    text <- paste(text %||% read(file), collapse = "\n")
+    jsonlite::fromJSON(txt = text, simplifyVector = FALSE)
+  }
+  
+  renv_json_read_default <- function(file = NULL, text = NULL) {
+  
+    # find strings in the JSON
+    text <- paste(text %||% read(file), collapse = "\n")
+    pattern <- '["](?:(?:\\\\.)|(?:[^"\\\\]))*?["]'
+    locs <- gregexpr(pattern, text, perl = TRUE)[[1]]
+  
+    # if any are found, replace them with placeholders
+    replaced <- text
+    strings <- character()
+    replacements <- character()
+  
+    if (!identical(c(locs), -1L)) {
+  
+      # get the string values
+      starts <- locs
+      ends <- locs + attr(locs, "match.length") - 1L
+      strings <- substring(text, starts, ends)
+  
+      # only keep those requiring escaping
+      strings <- grep("[[\\]{}:]", strings, perl = TRUE, value = TRUE)
+  
+      # compute replacements
+      replacements <- sprintf('"\032%i\032"', seq_along(strings))
+  
+      # replace the strings
+      mapply(function(string, replacement) {
+        replaced <<- sub(string, replacement, replaced, fixed = TRUE)
+      }, strings, replacements)
+  
+    }
+  
+    # transform the JSON into something the R parser understands
+    transformed <- replaced
+    transformed <- gsub("{}", "`names<-`(list(), character())", transformed, fixed = TRUE)
+    transformed <- gsub("[[{]", "list(", transformed, perl = TRUE)
+    transformed <- gsub("[]}]", ")", transformed, perl = TRUE)
+    transformed <- gsub(":", "=", transformed, fixed = TRUE)
+    text <- paste(transformed, collapse = "\n")
+  
+    # parse it
+    json <- parse(text = text, keep.source = FALSE, srcfile = NULL)[[1L]]
+  
+    # construct map between source strings, replaced strings
+    map <- as.character(parse(text = strings))
+    names(map) <- as.character(parse(text = replacements))
+  
+    # convert to list
+    map <- as.list(map)
+  
+    # remap strings in object
+    remapped <- renv_json_remap(json, map)
+  
+    # evaluate
+    eval(remapped, envir = baseenv())
+  
+  }
+  
+  renv_json_remap <- function(json, map) {
+  
+    # fix names
+    if (!is.null(names(json))) {
+      lhs <- match(names(json), names(map), nomatch = 0L)
+      rhs <- match(names(map), names(json), nomatch = 0L)
+      names(json)[rhs] <- map[lhs]
+    }
+  
+    # fix values
+    if (is.character(json))
+      return(map[[json]] %||% json)
+  
+    # handle true, false, null
+    if (is.name(json)) {
+      text <- as.character(json)
+      if (text == "true")
+        return(TRUE)
+      else if (text == "false")
+        return(FALSE)
+      else if (text == "null")
+        return(NULL)
+    }
+  
+    # recurse
+    if (is.recursive(json)) {
+      for (i in seq_along(json)) {
+        json[i] <- list(renv_json_remap(json[[i]], map))
+      }
+    }
+  
+    json
+  
+  }
+
+  # load the renv profile, if any
+  renv_bootstrap_profile_load(project)
+
+  # construct path to library root
+  root <- renv_bootstrap_library_root(project)
+
+  # construct library prefix for platform
+  prefix <- renv_bootstrap_platform_prefix()
+
+  # construct full libpath
+  libpath <- file.path(root, prefix)
+
+  # attempt to load
+  if (renv_bootstrap_load(project, libpath, version))
+    return(TRUE)
+
+  if (renv_bootstrap_in_rstudio()) {
+    setHook("rstudio.sessionInit", function(...) {
+      renv_bootstrap_run(version, libpath)
+
+      # Work around buglet in RStudio if hook uses readline
+      tryCatch(
+        {
+          tools <- as.environment("tools:rstudio")
+          tools$.rs.api.sendToConsole("", echo = FALSE, focus = FALSE)
+        },
+        error = function(cnd) {}
+      )
+    })
+  } else {
+    renv_bootstrap_run(version, libpath)
+  }
+
+  invisible()
+
+})

--- a/crossbow-nightly-report/renv/settings.json
+++ b/crossbow-nightly-report/renv/settings.json
@@ -1,0 +1,19 @@
+{
+  "bioconductor.version": null,
+  "external.libraries": [],
+  "ignored.packages": [],
+  "package.dependency.fields": [
+    "Imports",
+    "Depends",
+    "LinkingTo"
+  ],
+  "ppm.enabled": null,
+  "ppm.ignored.urls": [],
+  "r.version": null,
+  "snapshot.type": "implicit",
+  "use.cache": true,
+  "vcs.ignore.cellar": true,
+  "vcs.ignore.library": true,
+  "vcs.ignore.local": true,
+  "vcs.manage.ignores": true
+}

--- a/csv_reports/README.md
+++ b/csv_reports/README.md
@@ -1,3 +1,0 @@
-# Nightly CSV reports
-
-Nightly report CSVs are stored on this folder.


### PR DESCRIPTION
This PR is a draft to address #55. To do this I have ported the report to become a quarto doc rather than rmarkdown and then written the viz in javascript for more interactivity.

Because the way this is implemented, it needs to be served up via https rather than a local html file. So screenshots it is. Here is the default which sets the x-axes to extend to the last 120 days:

![image](https://github.com/ursacomputing/crossbow/assets/18472598/8bb172a8-1cc4-47b1-b384-2bef0f721c58)

but we can slide to only look at the last ten days:

![image](https://github.com/ursacomputing/crossbow/assets/18472598/30b34d76-dfa2-466c-ad8f-42bf20e107b1)

or look at the past 6 months:

![image](https://github.com/ursacomputing/crossbow/assets/18472598/c3c7d66a-7c71-4225-8952-d6b91576b6aa)

Also included here is a tooltip which gives some specific info:

![image](https://github.com/ursacomputing/crossbow/assets/18472598/3f9f4ac3-81a7-4feb-954f-436810927ddc)

I have also updated the build table to include passing runs. Because this adds a significant amount of rows to the table, I've implemented some interactivity for the build table. This looks like this:

<img width="1137" alt="image" src="https://github.com/ursacomputing/crossbow/assets/18472598/8eb9f95c-f85e-4fa6-b77d-f4926121cd6c">



I am hoping that @raulcd or @assignUser can offer some thoughts on this change. 

TODO before merging this:
- ~revise the workflow to use quarto instead of rmarkdown~
- ~final tweaks to polish trend plot~
- ~implement any suggestions.~
