### PR TITLE
Visualize and interact with micro benchmarks in performance report

### DIFF
--- a/.github/workflows/performance-release-report.yml
+++ b/.github/workflows/performance-release-report.yml
@@ -33,8 +33,8 @@ permissions:
   
 env: 
     ## payload vars
-    BASELINE_GIT_COMMIT: ${{ github.event.inputs.baseline_git_commit }}
-    CONTENDER_GIT_COMMIT: ${{ github.event.inputs.contender_git_commit }}
+    BASELINE_GIT_COMMIT: ${{ github.event.inputs.baseline_git_commit || 5bf86ab4d9e9bc5bb7e1c6e65a55d9f1723597bf }}
+    CONTENDER_GIT_COMMIT: ${{ github.event.inputs.contender_git_commit || b7d2f7ffca66c868bd2fce5b3749c6caa002a7f0 }}
     RC_LABEL: ${{ github.event.inputs.rc_label || 'manual' }}
 
 jobs:

--- a/.github/workflows/performance-release-report.yml
+++ b/.github/workflows/performance-release-report.yml
@@ -33,8 +33,8 @@ permissions:
   
 env: 
     ## payload vars
-    BASELINE_GIT_COMMIT: ${{ github.event.inputs.baseline_git_commit || 5bf86ab4d9e9bc5bb7e1c6e65a55d9f1723597bf }}
-    CONTENDER_GIT_COMMIT: ${{ github.event.inputs.contender_git_commit || b7d2f7ffca66c868bd2fce5b3749c6caa002a7f0 }}
+    BASELINE_GIT_COMMIT: ${{ github.event.inputs.baseline_git_commit }}
+    CONTENDER_GIT_COMMIT: ${{ github.event.inputs.contender_git_commit }}
     RC_LABEL: ${{ github.event.inputs.rc_label || 'manual' }}
 
 jobs:

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,7 @@
 performance-release-report.html
+performance-release-report_cache
+performance-release-report_files
+performance-release-report.html
 crossbow-nightly-report.html
 crossbow-nightly-report_cache
 all.yml

--- a/performance-release-report/R/functions.R
+++ b/performance-release-report/R/functions.R
@@ -78,7 +78,6 @@ plot_comparison <- function(plot_df, alpha = 0.7) {
   }
 
   title <- glue::glue("{unique(plot_df$language)}: {unique(plot_df$benchmark_name)}")
-
   p <- plot_df %>%
     mutate(change_lab = change * 1.05) %>%
     ggplot() +
@@ -86,8 +85,10 @@ plot_comparison <- function(plot_df, alpha = 0.7) {
     geom_col_interactive(
       aes(
         tooltip = glue(
-          "Percent change: {round(change, 2)}%\n",
+          "Baseline raw value: {baseline.single_value_summary}{unit}\n",
+          "Contender raw value: {contender.single_value_summary}{unit}\n",
           "Difference: {difference}\n",
+          "Percent change: {round(change, 2)}%\n",
           "Dataset: {dataset}"
         )
       ),
@@ -142,7 +143,7 @@ tidy_compare <- function(.x, .y) {
     select(-any_of(c("baseline_tags.dataset", "baseline_tags.language"))) %>%
     rename_with(~ gsub("baseline_tags.", "", .)) %>%
     mutate(change = analysis.pairwise.percent_change) %>%
-    mutate(difference = paste0(round((baseline.single_value_summary - contender.single_value_summary) * 1000, 4), "", unit)) %>%
+    mutate(difference = paste0(round((baseline.single_value_summary - contender.single_value_summary), 4), "", unit)) %>%
     mutate(
       pn_lab = case_when(
         analysis.pairwise.percent_change == 0 ~ "no change",

--- a/performance-release-report/R/functions.R
+++ b/performance-release-report/R/functions.R
@@ -144,6 +144,7 @@ tidy_compare <- function(.x, .y) {
     rename_with(~ gsub("baseline_tags.", "", .)) %>%
     mutate(change = analysis.pairwise.percent_change) %>%
     mutate(difference = paste0(round((baseline.single_value_summary - contender.single_value_summary), 4), "", unit)) %>%
+    mutate(cb_url = glue('https://conbench.ursa.dev/benchmark-results/{baseline.benchmark_result_id}/')) %>% 
     mutate(
       pn_lab = case_when(
         analysis.pairwise.percent_change == 0 ~ "no change",
@@ -182,9 +183,11 @@ top_zscore_table <- function(.data, top_n = 20, direction = c("improvement", "re
 
   .data %>%
     head(top_n) %>%
+    mutate(name = glue("[{name}]({cb_url})")) %>%
     select(language, suite, name, params, analysis_lookback_z_score_z_score, analysis_lookback_z_score_z_threshold, baseline_single_value_summary, contender_single_value_summary) %>%
     arrange(language, suite, name, params) %>% 
     gt(rowname_col = "language", groupname_col = "suite") %>%
+    fmt_markdown(columns = "name") %>% 
     cols_label(
       language = "Language",
       name = "Benchmark",

--- a/performance-release-report/R/functions.R
+++ b/performance-release-report/R/functions.R
@@ -143,3 +143,13 @@ tidy_compare <- function(.x, .y) {
       benchmark_name = .y$`baseline$benchmark_name`
     )
 }
+
+
+generate_compare_url <- function(x) {
+  baseline_id <- unique(x$baseline$run_id)
+  baseline_id <- baseline_id[!is.na(baseline_id)]
+  contender_id <- unique(x$contender$run_id)
+  contender_id <- contender_id[!is.na(contender_id)]
+
+  glue("https://conbench.ursa.dev/compare/runs/{contender_id}...{baseline_id}")
+}

--- a/performance-release-report/R/functions.R
+++ b/performance-release-report/R/functions.R
@@ -153,3 +153,30 @@ generate_compare_url <- function(x) {
 
   glue("https://conbench.ursa.dev/compare/runs/{contender_id}...{baseline_id}")
 }
+
+
+top_zscore_table <- function(.data, top_n = 20, direction = c("positive", "negative")) {
+  direction <- match.arg(direction)
+
+  if (direction == "positive") {
+    .data <- .data %>%
+      arrange(desc(analysis_lookback_z_score_z_score))
+  } else {
+    .data <- .data %>%
+      arrange(analysis_lookback_z_score_z_score)
+  }
+
+  .data %>%
+    head(top_n) %>%
+    select(language, name, suite, params, analysis_lookback_z_score_z_score) %>%
+    gt() %>%
+    cols_label(
+      language = "Language",
+      name = "Benchmark",
+      suite = "Suite",
+      params = "Params",
+      analysis_lookback_z_score_z_score = "z-score"
+    ) %>%
+    opt_table_font(font = google_font("Roboto Mono")) %>%
+    tab_options(table.font.size = "10px")
+}

--- a/performance-release-report/R/functions.R
+++ b/performance-release-report/R/functions.R
@@ -85,8 +85,8 @@ plot_comparison <- function(plot_df, alpha = 0.7) {
     geom_col_interactive(
       aes(
         tooltip = glue(
-          "Baseline raw value: {baseline.single_value_summary}{unit}\n",
-          "Contender raw value: {contender.single_value_summary}{unit}\n",
+          "Baseline result: {baseline.single_value_summary}{unit}\n",
+          "Contender result: {contender.single_value_summary}{unit}\n",
           "Difference: {difference}\n",
           "Percent change: {round(change, 2)}%\n",
           "Dataset: {dataset}"
@@ -169,10 +169,10 @@ generate_compare_url <- function(x) {
 }
 
 
-top_zscore_table <- function(.data, top_n = 20, direction = c("positive", "negative")) {
+top_zscore_table <- function(.data, top_n = 20, direction = c("improvement", "regression")) {
   direction <- match.arg(direction)
 
-  if (direction == "positive") {
+  if (direction == "improvement") {
     .data <- .data %>%
       arrange(desc(analysis_lookback_z_score_z_score))
   } else {
@@ -182,13 +182,17 @@ top_zscore_table <- function(.data, top_n = 20, direction = c("positive", "negat
 
   .data %>%
     head(top_n) %>%
-    select(language, name, suite, params, analysis_lookback_z_score_z_score) %>%
-    gt() %>%
+    select(language, suite, name, params, analysis_lookback_z_score_z_score, analysis_lookback_z_score_z_threshold, baseline_single_value_summary, contender_single_value_summary) %>%
+    arrange(language, suite, name, params) %>% 
+    gt(rowname_col = "language", groupname_col = "suite") %>%
     cols_label(
       language = "Language",
       name = "Benchmark",
       suite = "Suite",
       params = "Params",
+      baseline_single_value_summary = "Baseline result",
+      contender_single_value_summary = "Contender result",
+      analysis_lookback_z_score_z_threshold = "z-score threshold",
       analysis_lookback_z_score_z_score = "z-score"
     ) %>%
     opt_table_font(font = google_font("Roboto Mono")) %>%

--- a/performance-release-report/R/functions.R
+++ b/performance-release-report/R/functions.R
@@ -1,0 +1,145 @@
+#' Find runs for a given hardware name and two git commits
+#' A wrapper around conbenchcoms::runs()
+#' 
+#' @return A tibble of runs (or an empty tibble if no runs were found)
+
+find_runs <- function(baseline_git_commit, contender_git_commit, hardware_name) {
+  runs_raw <- conbenchcoms::runs(c(baseline_git_commit, contender_git_commit))
+  if (length(runs_raw) == 0) {
+    message("This combination of commits did not return any runs.")
+    return(invisible(tibble::tibble()))
+  }
+
+  runs_raw %>%
+    dplyr::filter(hardware.name %in% hardware_name) %>%
+    dplyr::mutate(run_type = case_when(
+      commit.sha == contender_git_commit ~ "contender",
+      commit.sha == baseline_git_commit ~ "baseline"
+    )) %>%
+    dplyr::mutate(dplyr::across(dplyr::starts_with("links"), conbenchcoms::url_cleaner))
+}
+
+#' A wrapper around conbenchcoms::compare() which looks for
+#' contender and baseline runs in the given data frame
+compare_baseline_to_contender <- function(.data) {
+  compare(
+    type = "runs",
+    .data$id[.data$run_type == "baseline"],
+    .data$id[.data$run_type == "contender"],
+    simplifyVector = TRUE
+  ) %>%
+    as_tibble()
+}
+
+
+
+#' Detect if we are on GitHub Actions
+is_gha <- function() {
+  Sys.getenv("GITHUB_ACTIONS") == "true"
+}
+
+
+plot_comparison <- function(plot_df, alpha = 0.7) {
+
+  ## Can be a uri as well
+  plot_df <- plot_df %>% 
+    mutate(dataset = case_when(
+      is.na(dataset) ~ dataset_uri,
+      TRUE ~ dataset
+    ))
+
+  tag_names <- unlist(plot_df$tags_used)
+  x_facets <- c("compression", "format", "file_type", "use_legacy_dataset")
+  # TODO: add others?
+  x_facets <- x_facets[x_facets %in% tag_names]
+
+  y_facets <- c("output_type", "input_type", "streaming", "pre_buffer", "async", "selectivity", "scale_factor")
+  y_facets <- y_facets[y_facets %in% tag_names]
+
+  maybe_vars <- function(variables) {
+    if (length(variables) == 0) {
+      return(NULL)
+    }
+
+    vars(!!!syms(variables))
+  }
+
+  title <- glue::glue("{unique(plot_df$language)}: {unique(plot_df$benchmark_name)}")
+
+  p <- plot_df %>%
+    mutate(change_lab = change * 1.05) %>%
+    ggplot() +
+    aes(y = forcats::fct_reorder(dataset, pn_lab, .desc = TRUE), x = change, fill = pn_lab) +
+    geom_col_interactive(
+      aes(
+        tooltip = glue(
+          "Percent change: {round(change, 2)}%\n",
+          "Difference: {difference}\n",
+          "Dataset: {dataset}"
+        )
+      ),
+      position = "dodge", alpha = 0.75, width = 0.75, colour = "grey 40"
+    ) +
+    geom_vline(xintercept = 0, colour = "grey50") +
+    geom_text(aes(x = change_lab, hjust = ifelse(change >= 0, 0, 1), label = difference, colour = pn_lab), size = 6) +
+    facet_grid(rows = maybe_vars(x_facets), cols = maybe_vars(y_facets), labeller = label_both) +
+    scale_fill_manual(values = change_cols) +
+    scale_colour_manual(values = change_cols) +
+    scale_x_continuous(expand = expansion(mult = 0.6)) +
+    guides(colour = "none") +
+    ylab("Dataset") +
+    xlab("% change")
+  
+  ## Some height adjustments
+  g_heights <- 6
+  g_widths <- 16
+
+  if (length(x_facets) > 0) {
+    g_heights <- g_heights*(n_distinct(plot_df[, x_facets, drop = TRUE])/1.25)
+  }
+  girafe(
+    ggobj = p,
+    options = list(
+      opts_tooltip(use_fill = TRUE),
+      opts_sizing(width = .7)
+    ),
+    width_svg = g_widths,
+    height_svg = g_heights
+  )
+}
+
+#' Take a language and benchmark name combo and return a processed tibble
+#' with some relevant columns brought to the top level
+#' @param .x language
+#' @param .y benchmark name
+#' @return tibble
+tidy_compare <- function(.x, .y) {
+  tags <- .x$baseline_tags[colSums(!is.na(.x$baseline_tags)) > 0]
+
+  if (length(unique(tags$name)) > 1) {
+    browser()
+  }
+
+  tag_names <- colnames(tags)
+  tag_names <- tag_names[!tag_names %in% c("name", "query_id", "language", "engine", "memory_map", "query", "async")]
+
+  plot_df <- .x %>%
+    jsonlite::flatten() %>%
+    as_tibble() %>%
+    select(-any_of(c("baseline_tags.dataset", "baseline_tags.language"))) %>%
+    rename_with(~ gsub("baseline_tags.", "", .)) %>%
+    mutate(change = analysis.pairwise.percent_change) %>%
+    mutate(difference = paste0(round((baseline.single_value_summary - contender.single_value_summary) * 1000, 4), "", unit)) %>%
+    mutate(
+      pn_lab = case_when(
+        analysis.pairwise.percent_change == 0 ~ "no change",
+        analysis.pairwise.percent_change > 0 ~ paste0(contender_git_commit_short, " (contender) faster"),
+        analysis.pairwise.percent_change < 0 ~ paste0(baseline_git_commit_short, " (baseline) faster")
+      )
+    ) %>%
+    mutate(
+      tags_used = list(tag_names),
+      language = .y$`baseline$language`,
+      benchmark_name = .y$`baseline$benchmark_name`
+    )
+}

--- a/performance-release-report/R/functions.R
+++ b/performance-release-report/R/functions.R
@@ -32,6 +32,19 @@ compare_baseline_to_contender <- function(.data) {
 }
 
 
+#' helper function to get the language summary from a comparison
+get_language_summary_from_comparison <- function(.data) {
+  Reduce(bind_rows, .data[c("baseline", "contender")]) %>%
+    filter(!is.na(language)) %>%
+    summarise(
+      languages = paste(unique(language), collapse = ", "),
+      n_benchmarks = length(benchmark_name),
+      .by = run_id
+    )
+}
+
+
+
 
 #' Detect if we are on GitHub Actions
 is_gha <- function() {

--- a/performance-release-report/performance-release-report.qmd
+++ b/performance-release-report/performance-release-report.qmd
@@ -306,6 +306,54 @@ micro_bm_proced <- micro_bm_df %>%
 ```
 
 
+```{r ojs-defn}
+ojs_define(ojs_micro_bm_proced = micro_bm_proced)
+```
+
+```{ojs setup-micro-bm}
+Plot = await import("https://esm.sh/@observablehq/plot");
+import { aq, op } from '@uwdata/arquero';
+boxWidth = 900
+microBmProced = aq.from(transpose(ojs_micro_bm_proced))
+
+// Choose the language
+allLanguageValues = microBmProced.dedupe('language').array('language')
+
+viewof languageSelected = Inputs.select(allLanguageValues, {
+    label: md`**Language**`,
+    value: [allLanguageValues[0]],
+    width: boxWidth
+})
+
+// Choose the suite
+allSuiteValues = microBmProced
+    .filter(aq.escape(d => op.equal(d.language, languageSelected)))
+    .dedupe('suite').array('suite')
+
+viewof suiteSelected = Inputs.select(allSuiteValues, {
+    label: md`**Suite**`,
+    value: [allSuiteValues[0]],
+    width: boxWidth
+})
+
+// Choose the benchmark
+allNameValues = microBmProced
+    .filter(aq.escape(d => op.equal(d.language, languageSelected)))
+    .filter(aq.escape(d => op.equal(d.suite, suiteSelected)))
+    .dedupe('name').array('name')
+
+viewof nameSelected = Inputs.select(allNameValues, {
+    label: md`**Name**`,
+    value: [allNameValues[0]],
+    width: boxWidth
+})
+
+microBmProced
+    .filter(aq.escape(d => op.equal(d.language, languageSelected)))
+    .filter(aq.escape(d => op.equal(d.suite, suiteSelected)))
+    .filter(aq.escape(d => op.equal(d.name, nameSelected))).view()
+```
+
 ```{css, echo=FALSE}
 div.main-container {
   max-width: 2000px;

--- a/performance-release-report/performance-release-report.qmd
+++ b/performance-release-report/performance-release-report.qmd
@@ -323,7 +323,7 @@ micro_bm_proced <- micro_bm_df %>%
   ungroup() %>% 
   filter(!is.na(name)) %>% 
   clean_names() %>% 
-  select(language, baseline_benchmark_name, name, params, suite, analysis_pairwise_regression_indicated, analysis_pairwise_improvement_indicated, change, difference, pn_lab, analysis_lookback_z_score_z_score, analysis_lookback_z_score_z_threshold, baseline_single_value_summary, contender_single_value_summary)
+  select(language, baseline_benchmark_name, name, params, suite, analysis_pairwise_regression_indicated, analysis_pairwise_improvement_indicated, change, difference, pn_lab, analysis_lookback_z_score_z_score, analysis_lookback_z_score_z_threshold, baseline_single_value_summary, contender_single_value_summary, cb_url)
 ```
 
 There are currently `r nrow(micro_bm_proced)` microbenchmarks in the Arrow benchmarks. The following comparisons are also available to be viewed in the [Conbench UI](`r generate_compare_url(micro_bm_df)`). 
@@ -376,7 +376,7 @@ top_zscore_table(micro_bm_proced, direction = "improvement")
 
 ## z-score distribution
 
-Plotting the distribution of zscores for all benchmark results will help identify any systematic differences between the baseline and contender. 
+Plotting the distribution of zscores for all microbenchmark results will help identify any systematic differences between the baseline and contender. The shape of the distribution of z-scores provides a sense of the overall performance of the contender relative to the baseline. Narrow distirbutions centered around 0 indicate that the contender is performing similarly to the baseline. Wider distributions indicate that the contender is performing differently than the baseline with left skewing indicating regressions and right skewing indicating improvements.
  
 
 ```{ojs}
@@ -389,7 +389,7 @@ Plot.plot({
   width: 1000,
   height: 400,
   marks: [
-    Plot.rectY(microBmProced, Plot.binX({y: "count"}, {x: "analysis_lookback_z_score_z_score", fill: "suite", tip: true})),
+    Plot.rectY(microBmProced, Plot.binX({y: "count"}, {x: "analysis_lookback_z_score_z_score", fill: "grey", tip: true})),
     Plot.ruleY([0])
   ]
 })
@@ -410,7 +410,7 @@ microBmProced = aq.from(transpose(ojs_micro_bm_proced))
 
 ## Microbenchmark explorer
 
-Formal pairwise comparisons between the baseline and contender can further be broken down below by language, suite, and benchmark name. Additionally regressions and improvements can be filtered to show only those that are marked by conbench.
+Formal pairwise comparisons between the baseline and contender can further be broken down below by language, suite, and benchmark name. Additionally regressions and improvements can be filtered to show only those detected as a threshold level of `r threshold` z-scores.
 
 
 ```{ojs filter-micro-bm}
@@ -528,6 +528,7 @@ Plot.plot({
       fillOpacity: 0.75,
       sort: {y: "x"},
       channels: {difference: "difference", params: "params"}, 
+      href: "cb_url",
       tip: true
       }),
     Plot.gridX({stroke: "white", strokeOpacity: 0.5}),

--- a/performance-release-report/performance-release-report.qmd
+++ b/performance-release-report/performance-release-report.qmd
@@ -138,12 +138,9 @@ if (Sys.Date() %in% unique(as.Date(hardware_summary$commit.timestamp))) {
 }
 ```
 
+# Macrobenchmarks
 
 
-# Benchmark Percent Changes
-
-- Benchmarks are plotted using the percent change from baseline to contender. 
-- Additional information on each benchmark is available by hovering over the relevant bar.
 
 ```{r function-plots}
 #| include: false
@@ -190,6 +187,13 @@ tpch_data <- macro_bm_list[["R"]][["tpch"]]
 
 macro_bm_list[["R"]][which(names(macro_bm_list[["R"]]) %in% c("tpch"))] <- NULL
 ```
+
+- [Conbench compare url](`r generate_compare_url(macro_bm_df)`)
+
+## Benchmark Percent Changes
+
+- Benchmarks are plotted using the percent change from baseline to contender. 
+- Additional information on each benchmark is available by hovering over the relevant bar.
 
 ## Python
 ```{r plot-python}
@@ -286,6 +290,8 @@ girafe(
 
 # Microbenchmarks
 
+
+
 ```{r compute-process-micro-bm-data}
 #| cache: !expr '!is_gha()'
 
@@ -305,6 +311,8 @@ micro_bm_proced <- micro_bm_df %>%
   clean_names() %>% 
   select(language, baseline_benchmark_name, name, params, suite, analysis_pairwise_regression_indicated, analysis_pairwise_improvement_indicated, change, difference, pn_lab)
 ```
+
+- [Conbench compare url](`r generate_compare_url(micro_bm_df)`)
 
 There are currently `r nrow(micro_bm_proced)` microbenchmarks in the Arrow benchmarks. Because of this volume, formal pairwise comparisons between the baseline and contender can further be broken down below by language, suite, and benchmark name. Additionally regressions and improvements can be filtered to show only those that are marked by conbench.
 
@@ -408,8 +416,6 @@ microBmProcedChangesFiltered = microBmProcedChanges
     .filter(aq.escape(d => op.equal(d.language, languageSelected)))
     .filter(aq.escape(d => op.equal(d.suite, suiteSelected)))
     .filter(aq.escape(d => op.equal(d.name, nameSelected)))
-
-microBmProcedChanges.view()
 ```
 
 ```{ojs plot-micro-bm}

--- a/performance-release-report/performance-release-report.qmd
+++ b/performance-release-report/performance-release-report.qmd
@@ -43,6 +43,7 @@ library(gt)
 library(forcats)
 library(showtext)
 library(ggiraph)
+library(janitor)
 
 ## add fonts for ggplot2
 ## TODO: add for tooltip font
@@ -283,9 +284,7 @@ girafe(
 ```
 
 
-## Microbenchmarks
-
-Float regressions to the top
+# Microbenchmarks
 
 ```{r compute-process-micro-bm-data}
 #| cache: !expr '!is_gha()'
@@ -302,7 +301,9 @@ micro_bm_proced <- micro_bm_df %>%
   group_by(baseline$language, baseline$benchmark_name) %>%
   group_modify(~ tidy_compare(.x, .y)) %>% 
   ungroup() %>% 
-  filter(!is.na(name))
+  filter(!is.na(name)) %>% 
+  clean_names() %>% 
+  select(language, baseline_benchmark_name, name, params, suite, analysis_pairwise_regression_indicated, analysis_pairwise_improvement_indicated, change, difference, pn_lab)
 ```
 
 
@@ -315,9 +316,39 @@ Plot = await import("https://esm.sh/@observablehq/plot");
 import { aq, op } from '@uwdata/arquero';
 boxWidth = 900
 microBmProced = aq.from(transpose(ojs_micro_bm_proced))
+```
+
+```{ojs filter-micro-bm}
+// Top level: are there regressions/improvements?
+viewof changes = Inputs.checkbox(["Regressions", "Improvements"], {
+  label: md`**Benchmark Status**`,
+  value: "Regressions"
+  })
+
+// Choose the state of the benchmark
+microBmProcedChanges = {
+  let microBmProcedParams;
+  let hasRegressions = changes.includes("Regressions");
+  let hasImprovements = changes.includes("Improvements");
+  microBmProcedParams = microBmProced
+      .params({hr: hasRegressions, hi: hasImprovements})
+  if (hasRegressions && hasImprovements) {
+    microBmProcedParams = microBmProced
+      .filter((d, $) => d.analysis_pairwise_regression_indicated==$.hr || d.analysis_pairwise_improvement_indicated==$.hi);
+  } else if (hasImprovements) {
+    microBmProcedParams = microBmProced
+      .filter((d, $) => d.analysis_pairwise_improvement_indicated==$.hi)
+  } else if (hasRegressions) {
+    microBmProcedParams = microBmProced
+      .filter((d, $) => d.analysis_pairwise_regression_indicated==$.hr);
+  } else {
+    microBmProcedParams = microBmProced;
+  }
+  return microBmProcedParams;
+}
 
 // Choose the language
-allLanguageValues = microBmProced.dedupe('language').array('language')
+allLanguageValues = microBmProcedChanges.dedupe('language').array('language')
 
 viewof languageSelected = Inputs.select(allLanguageValues, {
     label: md`**Language**`,
@@ -326,7 +357,7 @@ viewof languageSelected = Inputs.select(allLanguageValues, {
 })
 
 // Choose the suite
-allSuiteValues = microBmProced
+allSuiteValues = microBmProcedChanges
     .filter(aq.escape(d => op.equal(d.language, languageSelected)))
     .dedupe('suite').array('suite')
 
@@ -337,7 +368,7 @@ viewof suiteSelected = Inputs.select(allSuiteValues, {
 })
 
 // Choose the benchmark
-allNameValues = microBmProced
+allNameValues = microBmProcedChanges
     .filter(aq.escape(d => op.equal(d.language, languageSelected)))
     .filter(aq.escape(d => op.equal(d.suite, suiteSelected)))
     .dedupe('name').array('name')
@@ -348,11 +379,18 @@ viewof nameSelected = Inputs.select(allNameValues, {
     width: boxWidth
 })
 
-microBmProced
+microBmProcedChangesFiltered = microBmProcedChanges
     .filter(aq.escape(d => op.equal(d.language, languageSelected)))
     .filter(aq.escape(d => op.equal(d.suite, suiteSelected)))
-    .filter(aq.escape(d => op.equal(d.name, nameSelected))).view()
+    .filter(aq.escape(d => op.equal(d.name, nameSelected)))
+
+microBmProcedChanges.view()
 ```
+
+```{ojs plot-micro-bm}
+
+```
+
 
 ```{css, echo=FALSE}
 div.main-container {

--- a/performance-release-report/performance-release-report.qmd
+++ b/performance-release-report/performance-release-report.qmd
@@ -292,8 +292,6 @@ girafe(
 
 # Microbenchmarks
 
-
-
 ```{r compute-process-micro-bm-data}
 #| cache: !expr '!is_gha()'
 
@@ -311,12 +309,10 @@ micro_bm_proced <- micro_bm_df %>%
   ungroup() %>% 
   filter(!is.na(name)) %>% 
   clean_names() %>% 
-  select(language, baseline_benchmark_name, name, params, suite, analysis_pairwise_regression_indicated, analysis_pairwise_improvement_indicated, change, difference, pn_lab)
+  select(language, baseline_benchmark_name, name, params, suite, analysis_pairwise_regression_indicated, analysis_pairwise_improvement_indicated, change, difference, pn_lab, analysis_lookback_z_score_z_score)
 ```
 
-- [Conbench compare url](`r generate_compare_url(micro_bm_df)`)
-
-There are currently `r nrow(micro_bm_proced)` microbenchmarks in the Arrow benchmarks. Because of this volume, formal pairwise comparisons between the baseline and contender can further be broken down below by language, suite, and benchmark name. Additionally regressions and improvements can be filtered to show only those that are marked by conbench.
+There are currently `r nrow(micro_bm_proced)` microbenchmarks in the Arrow benchmarks. The following comparisons are also available to be viewed in the [conbench ui](`r generate_compare_url(micro_bm_df)`). 
 
 ```{r}
 micro_bm_proced %>% 
@@ -340,6 +336,50 @@ micro_bm_proced %>%
   opt_table_font(font = google_font("Roboto Mono"))
 ```
 
+Because of the large number of benchmarks, the top 20 benchmark results that deviate most from the baseline in both the positive and negative directions are presented below. 
+
+::: {.callout-important collapse="true"}
+
+## Top 20 negative z-scores
+
+```{r}
+top_zscore_table(micro_bm_proced, direction = "negative")
+```
+
+
+:::
+
+::: {.callout-note collapse="true"}
+
+## Top 20 positive z-scores
+
+```{r}
+top_zscore_table(micro_bm_proced, direction = "positive")
+```
+
+:::
+
+## z-score distribution
+
+Plotting the distribution of zscores for all benchmark results will help identify any systematic differences between the baseline and contender. 
+ 
+
+```{ojs}
+Plot.plot({
+  y: {grid: true},
+  x: {
+    label: "z-score"
+  },
+  color: {legend: false},
+  width: 1000,
+  height: 400,
+  marks: [
+    Plot.rectY(microBmProced, Plot.binX({y: "count"}, {x: "analysis_lookback_z_score_z_score", fill: "suite", tip: true})),
+    Plot.ruleY([0])
+  ]
+})
+```
+
 ```{r ojs-defn}
 ojs_define(ojs_micro_bm_proced = micro_bm_proced)
 ojs_define(ojs_change_cols = rev(change_cols))
@@ -352,6 +392,11 @@ import { aq, op } from '@uwdata/arquero';
 boxWidth = 900
 microBmProced = aq.from(transpose(ojs_micro_bm_proced))
 ```
+
+## Microbenchmark explorer
+
+Formal pairwise comparisons between the baseline and contender can further be broken down below by language, suite, and benchmark name. Additionally regressions and improvements can be filtered to show only those that are marked by conbench.
+
 
 ```{ojs filter-micro-bm}
 // Top level: are there regressions/improvements?
@@ -421,15 +466,33 @@ microBmProcedChangesFiltered = microBmProcedChanges
 ```
 
 ```{ojs plot-micro-bm}
+// long labels need special handlings
+margins = {
+  let hasRegressions = changes.includes("Regressions");
+  let hasImprovements = changes.includes("Improvements");
+  let margin = [300, 300];
+  if (hasRegressions && hasImprovements) {
+    margin = margin;
+  } else if (hasImprovements) {
+    margin = [0, 600];
+  } else if (hasRegressions) {
+    margin = [600, 0];
+  } 
+  return margin;
+}
+
 Plot.plot({
-  width: 1000,
-  height: 600,
-  grid: true,
+  width: 1200,
+  height: (microBmProcedChangesFiltered.numRows()*30)+100, //adjust height of plot based on number of rows
+  marginRight: margins[0],
+  marginLeft: margins[1],
   label: null,
   x: {
+    axis: "top",
     label: "% change",
     labelAnchor: "center",
-    percent: true
+    percent: true,
+    labelOffset: 30
   },
   style: {
     fontSize: "14px",
@@ -453,8 +516,17 @@ Plot.plot({
       tip: true
       }),
     Plot.gridX({stroke: "white", strokeOpacity: 0.5}),
-    Plot.axisY({x: 0}),
-    Plot.ruleX([0])
+    Plot.ruleX([0]),
+    d3
+      .groups(microBmProcedChangesFiltered, (d) => d.change > 0)
+      .map(([posneg, dat]) => [
+        Plot.axisY({
+          x: 0,
+          ticks: dat.map((d) => d.params),
+          tickSize: 0,
+          anchor: posneg ? "left" : "right"
+        }),
+      ])
   ]
 })
 ```

--- a/performance-release-report/performance-release-report.qmd
+++ b/performance-release-report/performance-release-report.qmd
@@ -341,7 +341,7 @@ micro_bm_proced <- micro_bm_df %>%
   ungroup() %>% 
   filter(!is.na(name)) %>% 
   clean_names() %>% 
-  select(language, baseline_benchmark_name, name, params, suite, analysis_pairwise_regression_indicated, analysis_pairwise_improvement_indicated, change, difference, pn_lab, analysis_lookback_z_score_z_score, analysis_lookback_z_score_z_threshold, baseline_single_value_summary, contender_single_value_summary, cb_url)
+  select(language, baseline_benchmark_name, name, params, suite, analysis_pairwise_regression_indicated, analysis_pairwise_improvement_indicated, change, difference, pn_lab, analysis_lookback_z_score_z_score, analysis_lookback_z_score_z_threshold, analysis_pairwise_percent_change, baseline_single_value_summary, contender_single_value_summary, cb_url, unit)
 ```
 
 There are currently `r nrow(micro_bm_proced)` microbenchmarks in the Arrow benchmarks. The following comparisons are also available to be viewed in the [Conbench UI](`r generate_compare_url(micro_bm_df)`). 
@@ -465,7 +465,7 @@ allLanguageValues = microBmProcedChanges.dedupe('language').array('language')
 
 viewof languageSelected = Inputs.select(allLanguageValues, {
     label: md`**Language**`,
-    value: [allLanguageValues[0]],
+    value: ["All languages"].concat([allLanguageValues[0]]),
     width: boxWidth
 })
 

--- a/performance-release-report/performance-release-report.qmd
+++ b/performance-release-report/performance-release-report.qmd
@@ -369,7 +369,7 @@ micro_bm_proced %>%
   opt_table_font(font = google_font("Roboto Mono"))
 ```
 
-Because of the large number of benchmarks, the top 20 benchmark results that deviate most from the baseline in both the positive and negative directions are presented below. 
+Because of the large number of benchmarks, the top 20 benchmark results that deviate most from the baseline in both the positive and negative directions are presented below. _All_ microbenchmark results for this comparison can be explored interactively in the [microbenchmark explorer](#micro-bm-explorer).
 
 ::: {.callout-important collapse="true"}
 
@@ -426,7 +426,7 @@ boxWidth = 900
 microBmProced = aq.from(transpose(ojs_micro_bm_proced))
 ```
 
-## Microbenchmark explorer
+## Microbenchmark explorer {#micro-bm-explorer}
 
 Formal pairwise comparisons between the baseline and contender can further be broken down below by language, suite, and benchmark name. Additionally regressions and improvements can be filtered to show only those detected as a threshold level of `r threshold` z-scores.
 

--- a/performance-release-report/performance-release-report.qmd
+++ b/performance-release-report/performance-release-report.qmd
@@ -226,7 +226,7 @@ tpch_data <- macro_bm_list[["R"]][["tpch"]]
 macro_bm_list[["R"]][which(names(macro_bm_list[["R"]]) %in% c("tpch"))] <- NULL
 ```
 
-Live Conbench UI views for the macrobenchmarks are available at this [url](`r generate_compare_url(macro_bm_df)`). This is an additional method to explore the results of the benchmarks. 
+Live Conbench UI views for the macrobenchmarks are available at this [url](`r generate_compare_url(macro_bm_df)`). Conbench is an additional method to explore the results of the benchmarks particularly if you want to see results from more of the history or see more metadata. 
 
 ## Benchmark Percent Changes
 

--- a/performance-release-report/performance-release-report.qmd
+++ b/performance-release-report/performance-release-report.qmd
@@ -100,7 +100,7 @@ if (length(runs_raw) == 0) {
 
 
 ```{r message-missing-hardware}
-#| results='asis'
+#| results: 'asis'
 
 if (nrow(hardware_summary) != 2) {
   ## fail early and informatively with when not using correct hardware
@@ -135,9 +135,8 @@ hardware_summary %>%
 ```{r message-same-day-commit}
 #| results: 'asis'
 
-# if (Sys.Date() %in% as.Date(hardware_summary$commit.timestamp)) {
-if (TRUE) {
-  ## fail early and informatively with when not using correct hardware
+if (Sys.Date() %in% as.Date(hardware_summary$commit.timestamp)) {
+  ## inform early and informatively with when not using correct hardware
   cat("::: {.callout-warning}\n")
   cat("You are trying to examine commits that were made today. It is possible that not all benchmarks have been completed yet and plots below may show unexpected results.\n")
   cat(":::\n")
@@ -230,7 +229,7 @@ plot_comparison <- function(plot_df, alpha = 0.7) {
 
 
 ```{r compute-process-data}
-#| results='asis'
+#| results: 'asis'
 
 # grab the run comparison from the API
 conbench_df <- compare(
@@ -379,7 +378,6 @@ tpch_p <- tpch_data %>%
   facet_grid(rows = vars(format), cols = vars(scale_factor), labeller = label_both) +
   scale_fill_manual(values = change_cols) +
   scale_colour_manual(values = change_cols) +
-  # ggtitle("TPCH") +
   scale_x_continuous(expand = expansion(mult = 0.6)) +
   guides(colour = "none") +
   ylab("Dataset") +

--- a/performance-release-report/performance-release-report.qmd
+++ b/performance-release-report/performance-release-report.qmd
@@ -85,6 +85,13 @@ To see the most up-to-date results, please run this report on GitHub Actions or 
 }
 ```
 
+
+```{r warn-commits-not-set}
+if (!nzchar(baseline_git_commit) | !nzchar(contender_git_commit)) {
+  knit_exit("Please set the BASELINE_GIT_COMMIT & CONTENDER_GIT_COMMIT environment variables to the commit hash of the baseline and the release.")
+}
+```
+
 ```{r compute-conbench-requests}
 #| include: false
 #| results: 'asis'

--- a/performance-release-report/performance-release-report.qmd
+++ b/performance-release-report/performance-release-report.qmd
@@ -26,8 +26,10 @@ format:
 
 Sys.unsetenv("CONBENCH_PASSWORD")
 
-baseline_git_commit <- Sys.getenv("BASELINE_GIT_COMMIT", '5bf86ab4d9e9bc5bb7e1c6e65a55d9f1723597bf') 
-contender_git_commit <-  Sys.getenv("CONTENDER_GIT_COMMIT", 'b7d2f7ffca66c868bd2fce5b3749c6caa002a7f0')
+# baseline_git_commit <- Sys.getenv("BASELINE_GIT_COMMIT", '5bf86ab4d9e9bc5bb7e1c6e65a55d9f1723597bf') 
+# contender_git_commit <-  Sys.getenv("CONTENDER_GIT_COMMIT", 'b7d2f7ffca66c868bd2fce5b3749c6caa002a7f0')
+baseline_git_commit <- '5bf86ab4d9e9bc5bb7e1c6e65a55d9f1723597bf'
+contender_git_commit <-  'b7d2f7ffca66c868bd2fce5b3749c6caa002a7f0'
 hardware_name <- c("ursa-i9-9960x", "ursa-thinkcentre-m75q")
 
 library(dplyr)

--- a/performance-release-report/performance-release-report.qmd
+++ b/performance-release-report/performance-release-report.qmd
@@ -2,6 +2,7 @@
 title: "Arrow Release Benchmark Report"
 execute: 
   warning: false
+  echo: false
 format: 
   html:
     grid:
@@ -27,7 +28,7 @@ Sys.unsetenv("CONBENCH_PASSWORD")
 
 baseline_git_commit <- Sys.getenv("BASELINE_GIT_COMMIT") 
 contender_git_commit <-  Sys.getenv("CONTENDER_GIT_COMMIT")
-hardware_name <- "ursa-i9-9960x"
+hardware_name <- c("ursa-i9-9960x", "ursa-thinkcentre-m75q")
 
 library(dplyr)
 library(ggplot2)
@@ -48,7 +49,6 @@ library(ggiraph)
 font_add_google('Roboto Mono', 'roboto')
 showtext_auto()
 
-
 fig_width <- 16
 fig_height <- 7
 
@@ -58,7 +58,7 @@ theme_set(theme_minimal(base_size = 24, base_family = "roboto") %+replace%
     plot.title.position = "plot",
     strip.text.y = element_text(angle = -90),
     strip.text = element_text(size = 18),
-    panel.border = element_rect(colour = "grey80", fill = NA, size = 1),
+    panel.border = element_rect(colour = "grey80", fill = NA, linewidth = 1),
     legend.title = element_blank(),
     legend.position = "top"
   ))
@@ -78,6 +78,7 @@ source("R/functions.R")
 ```{r compute-runs}
 #| include: false
 #| results: 'asis'
+#| cache: !expr '!is_gha()'
 
 run_comp <- find_runs(baseline_git_commit, contender_git_commit, hardware_name)
 
@@ -113,6 +114,7 @@ hardware_summary %>%
     commit.timestamp = ymd_hms(commit.timestamp)
     ) %>% 
   select(run_type, commit.sha, commit.timestamp, hardware.cpu_model_name) %>% 
+  arrange(hardware.cpu_model_name) %>% 
   gt() %>% 
   fmt_markdown(c("commit.sha", "run_type")) %>% 
   gt::cols_label(
@@ -127,7 +129,7 @@ hardware_summary %>%
 ```{r message-same-day-commit}
 #| results: 'asis'
 
-if (Sys.Date() %in% as.Date(hardware_summary$commit.timestamp)) {
+if (Sys.Date() %in% unique(as.Date(hardware_summary$commit.timestamp))) {
   ## inform early and informatively with when not using correct hardware
   cat("::: {.callout-warning}\n")
   cat("You are trying to examine commits that were made today. It is possible that not all benchmarks have been completed yet and plots below may show unexpected results.\n")
@@ -150,8 +152,9 @@ names(change_cols) <- c(glue("{contender_git_commit_short} (contender) faster"),
 ```
 
 
-```{r compute-process-data}
+```{r compute-process-macro-bm-data}
 #| results: 'asis'
+#| cache: !expr '!is_gha()'
 
 # Compare the baseline to the contender for 
 # macrobenchmarks
@@ -160,7 +163,7 @@ macro_bm_df <- run_comp %>%
   compare_baseline_to_contender() %>%
   filter(baseline$language %in% c("Python", "R"))
 
-conbench_proced <- conbench_df %>%
+macro_bm_proced <- macro_bm_df %>%
   # csv-read had very different kinds of runs
   filter(baseline$benchmark_name != "csv-read") %>%
   # Remove the "TPCH-" prefix and any 0 at the start of the number

--- a/performance-release-report/performance-release-report.qmd
+++ b/performance-release-report/performance-release-report.qmd
@@ -78,7 +78,7 @@ source("R/functions.R")
 ```
 
 
-```{r compute-runs}
+```{r compute-conbench-requests}
 #| include: false
 #| results: 'asis'
 #| cache: !expr '!is_gha()'
@@ -89,14 +89,27 @@ if (length(run_comp) == 0) {
   knit_exit("No runs found for the given commits. Please check that the commits are correct and that the benchmark runs have completed.")
 }
 
-hardware_summary <- run_comp %>%
-  mutate(commit.timestamp = ymd_hms(commit.timestamp)) %>%
-  distinct(run_type, links.self, commit.sha, commit.timestamp, commit.url, hardware.cpu_model_name)
+# Compare the baseline to the contender for 
+# macrobenchmarks
+macro_bm_df <- run_comp %>%
+  filter(hardware.name == "ursa-i9-9960x") %>%
+  compare_baseline_to_contender() %>%
+  filter(baseline$language %in% c("Python", "R")) ## still need to add in the JS benchmarks
+
+# microbenchmarks
+micro_bm_df <- run_comp %>%
+  filter(hardware.name == "ursa-thinkcentre-m75q") %>%
+  compare_baseline_to_contender()
 ```
 
 
 ```{r message-missing-hardware}
 #| results: 'asis'
+
+## extract hardware information
+hardware_summary <- run_comp %>%
+  mutate(commit.timestamp = ymd_hms(commit.timestamp)) %>%
+  distinct(run_type, links.self, commit.sha, commit.timestamp, commit.url, hardware.cpu_model_name, id)
 
 if (nrow(hardware_summary) != 2L*length(hardware_name)) {
   ## fail early and informatively with when not using correct hardware
@@ -110,21 +123,34 @@ if (nrow(hardware_summary) != 2L*length(hardware_name)) {
 
 # Benchmark Run Summary
 ```{r table-run-summary}
-hardware_summary %>% 
+
+## get additional information about the benchmarks
+benchmark_summary <- map_df(list(macro_bm_df, micro_bm_df), get_language_summary_from_comparison)
+
+
+run_summary <- hardware_summary %>%
+  left_join( ## join on run_id
+    benchmark_summary,
+    by = c("id" = "run_id")
+  ) %>%
   mutate(
     commit.sha = glue("[{substr(commit.sha, 1, 7)}]({commit.url})"),
     run_type = glue("[{run_type}]({links.self})"),
     commit.timestamp = ymd_hms(commit.timestamp)
-    ) %>% 
-  select(run_type, commit.sha, commit.timestamp, hardware.cpu_model_name) %>% 
-  arrange(hardware.cpu_model_name) %>% 
+  ) %>%
+  select(run_type, commit.sha, commit.timestamp, hardware.cpu_model_name, languages, n_benchmarks) %>%
+  arrange(hardware.cpu_model_name)
+
+run_summary %>% 
   gt() %>% 
   fmt_markdown(c("commit.sha", "run_type")) %>% 
   gt::cols_label(
     run_type = "Run Type",
     commit.sha = "Commit SHA",
     commit.timestamp = "Time of Commit",
-    hardware.cpu_model_name = "Hardware"
+    hardware.cpu_model_name = "Hardware",
+    languages = "Languages",
+    n_benchmarks = "Number of Benchmarks"
   ) %>% 
   opt_table_font(font = google_font("Roboto Mono"))
 ```
@@ -154,14 +180,6 @@ names(change_cols) <- c(glue("{contender_git_commit_short} (contender) faster"),
 
 ```{r compute-process-macro-bm-data}
 #| results: 'asis'
-#| cache: !expr '!is_gha()'
-
-# Compare the baseline to the contender for 
-# macrobenchmarks
-macro_bm_df <- run_comp %>%
-  filter(hardware.name == "ursa-i9-9960x") %>%
-  compare_baseline_to_contender() %>%
-  filter(baseline$language %in% c("Python", "R"))
 
 macro_bm_proced <- macro_bm_df %>%
   # csv-read had very different kinds of runs
@@ -293,11 +311,7 @@ girafe(
 # Microbenchmarks
 
 ```{r compute-process-micro-bm-data}
-#| cache: !expr '!is_gha()'
 
-micro_bm_df <- run_comp %>%
-  filter(hardware.name == "ursa-thinkcentre-m75q") %>%
-  compare_baseline_to_contender()
 
 ## unlike the plots above, this is added as single rectangular
 ## data.frame because that data structure is easier to work with

--- a/performance-release-report/performance-release-report.qmd
+++ b/performance-release-report/performance-release-report.qmd
@@ -326,7 +326,7 @@ micro_bm_proced <- micro_bm_df %>%
   select(language, baseline_benchmark_name, name, params, suite, analysis_pairwise_regression_indicated, analysis_pairwise_improvement_indicated, change, difference, pn_lab, analysis_lookback_z_score_z_score)
 ```
 
-There are currently `r nrow(micro_bm_proced)` microbenchmarks in the Arrow benchmarks. The following comparisons are also available to be viewed in the [conbench ui](`r generate_compare_url(micro_bm_df)`). 
+There are currently `r nrow(micro_bm_proced)` microbenchmarks in the Arrow benchmarks. The following comparisons are also available to be viewed in the [Conbench UI](`r generate_compare_url(micro_bm_df)`). 
 
 ```{r}
 micro_bm_proced %>% 

--- a/performance-release-report/performance-release-report.qmd
+++ b/performance-release-report/performance-release-report.qmd
@@ -306,9 +306,34 @@ micro_bm_proced <- micro_bm_df %>%
   select(language, baseline_benchmark_name, name, params, suite, analysis_pairwise_regression_indicated, analysis_pairwise_improvement_indicated, change, difference, pn_lab)
 ```
 
+There are currently `r nrow(micro_bm_proced)` microbenchmarks in the Arrow benchmarks. Because of this volume, formal pairwise comparisons between the baseline and contender can further be broken down below by language, suite, and benchmark name. Additionally regressions and improvements can be filtered to show only those that are marked by conbench.
+
+```{r}
+micro_bm_proced %>% 
+  count(language, analysis_pairwise_regression_indicated, analysis_pairwise_improvement_indicated) %>% 
+  mutate(col_var = case_when(
+    analysis_pairwise_regression_indicated == TRUE ~ "Regressions",
+    analysis_pairwise_improvement_indicated == TRUE ~ "Improvements",
+    TRUE ~ "Neither"
+  )) %>%
+  select(-all_of(starts_with("analysis"))) %>% 
+  pivot_wider(names_from = col_var, values_from = n) %>% 
+  rowwise() %>%
+  mutate(Total = sum(c_across(c(Neither, Improvements, Regressions)))) %>%
+  select(-Neither) %>%
+  gt() %>% 
+  cols_label(language = "Language") %>% 
+  tab_spanner(
+    label = "Number of microbenchmarks",
+    columns = c(Improvements, Regressions, Total)
+  ) %>%
+  opt_table_font(font = google_font("Roboto Mono"))
+```
 
 ```{r ojs-defn}
 ojs_define(ojs_micro_bm_proced = micro_bm_proced)
+ojs_define(ojs_change_cols = rev(change_cols))
+ojs_define(ojs_pn_lab = unique(micro_bm_proced$pn_lab))
 ```
 
 ```{ojs setup-micro-bm}
@@ -388,7 +413,42 @@ microBmProcedChanges.view()
 ```
 
 ```{ojs plot-micro-bm}
-
+Plot.plot({
+  width: 1000,
+  height: 600,
+  grid: true,
+  label: null,
+  x: {
+    label: "% change",
+    labelAnchor: "center",
+    percent: true
+  },
+  style: {
+    fontSize: "14px",
+    fontFamily: "Roboto Mono"
+    },
+  color: {
+    range: ojs_change_cols,
+    domain: ojs_pn_lab,
+    type: "categorical",
+    legend: true
+  },
+  marks: [
+    Plot.barX(microBmProcedChangesFiltered, {
+      y: "params", 
+      x: "change", 
+      color: "black",
+      fill: "pn_lab", 
+      fillOpacity: 0.75,
+      sort: {y: "x"},
+      channels: {difference: "difference", params: "params"}, 
+      tip: true
+      }),
+    Plot.gridX({stroke: "white", strokeOpacity: 0.5}),
+    Plot.axisY({x: 0}),
+    Plot.ruleX([0])
+  ]
+})
 ```
 
 

--- a/performance-release-report/performance-release-report.qmd
+++ b/performance-release-report/performance-release-report.qmd
@@ -26,10 +26,11 @@ format:
 
 Sys.unsetenv("CONBENCH_PASSWORD")
 
-# baseline_git_commit <- Sys.getenv("BASELINE_GIT_COMMIT", '5bf86ab4d9e9bc5bb7e1c6e65a55d9f1723597bf') 
-# contender_git_commit <-  Sys.getenv("CONTENDER_GIT_COMMIT", 'b7d2f7ffca66c868bd2fce5b3749c6caa002a7f0')
-baseline_git_commit <- '5bf86ab4d9e9bc5bb7e1c6e65a55d9f1723597bf'
-contender_git_commit <-  'b7d2f7ffca66c868bd2fce5b3749c6caa002a7f0'
+
+baseline_git_commit <- Sys.getenv("BASELINE_GIT_COMMIT") 
+contender_git_commit <-  Sys.getenv("CONTENDER_GIT_COMMIT")
+# baseline_git_commit <- '5bf86ab4d9e9bc5bb7e1c6e65a55d9f1723597bf'
+# contender_git_commit <-  'b7d2f7ffca66c868bd2fce5b3749c6caa002a7f0'
 hardware_name <- c("ursa-i9-9960x", "ursa-thinkcentre-m75q")
 
 library(dplyr)
@@ -77,6 +78,12 @@ contender_git_commit_short <- substr(contender_git_commit, 1, 7)
 source("R/functions.R")
 ```
 
+```{r warn-gha}
+if (!is_gha()) {
+  message("When run locally, this report will cache results to avoid re-running benchmarks. 
+To see the most up-to-date results, please run this report on GitHub Actions or delete the cache.")
+}
+```
 
 ```{r compute-conbench-requests}
 #| include: false

--- a/performance-release-report/performance-release-report.qmd
+++ b/performance-release-report/performance-release-report.qmd
@@ -208,7 +208,7 @@ tpch_data <- macro_bm_list[["R"]][["tpch"]]
 macro_bm_list[["R"]][which(names(macro_bm_list[["R"]]) %in% c("tpch"))] <- NULL
 ```
 
-- [Conbench compare url](`r generate_compare_url(macro_bm_df)`)
+Live Conbench UI views for the macrobenchmarks are available at this [url](`r generate_compare_url(macro_bm_df)`). This is an additional method to explore the results of the benchmarks. 
 
 ## Benchmark Percent Changes
 

--- a/performance-release-report/performance-release-report.qmd
+++ b/performance-release-report/performance-release-report.qmd
@@ -79,7 +79,7 @@ source("R/functions.R")
 ```{r compute-runs}
 #| include: false
 #| results: 'asis'
-#| cache: !expr '!is_gha()'
+
 
 run_comp <- find_runs(baseline_git_commit, contender_git_commit, hardware_name)
 
@@ -152,7 +152,7 @@ names(change_cols) <- c(glue("{contender_git_commit_short} (contender) faster"),
 
 ```{r compute-process-macro-bm-data}
 #| results: 'asis'
-#| cache: !expr '!is_gha()'
+
 
 # Compare the baseline to the contender for 
 # macrobenchmarks

--- a/performance-release-report/performance-release-report.qmd
+++ b/performance-release-report/performance-release-report.qmd
@@ -26,8 +26,8 @@ format:
 
 Sys.unsetenv("CONBENCH_PASSWORD")
 
-baseline_git_commit <- Sys.getenv("BASELINE_GIT_COMMIT") 
-contender_git_commit <-  Sys.getenv("CONTENDER_GIT_COMMIT")
+baseline_git_commit <- Sys.getenv("BASELINE_GIT_COMMIT", '5bf86ab4d9e9bc5bb7e1c6e65a55d9f1723597bf') 
+contender_git_commit <-  Sys.getenv("CONTENDER_GIT_COMMIT", 'b7d2f7ffca66c868bd2fce5b3749c6caa002a7f0')
 hardware_name <- c("ursa-i9-9960x", "ursa-thinkcentre-m75q")
 
 library(dplyr)

--- a/performance-release-report/performance-release-report.qmd
+++ b/performance-release-report/performance-release-report.qmd
@@ -79,7 +79,7 @@ source("R/functions.R")
 ```{r compute-runs}
 #| include: false
 #| results: 'asis'
-
+#| cache: !expr '!is_gha()'
 
 run_comp <- find_runs(baseline_git_commit, contender_git_commit, hardware_name)
 
@@ -152,7 +152,7 @@ names(change_cols) <- c(glue("{contender_git_commit_short} (contender) faster"),
 
 ```{r compute-process-macro-bm-data}
 #| results: 'asis'
-
+#| cache: !expr '!is_gha()'
 
 # Compare the baseline to the contender for 
 # macrobenchmarks

--- a/performance-release-report/performance-release-report.qmd
+++ b/performance-release-report/performance-release-report.qmd
@@ -111,14 +111,6 @@ if (nrow(hardware_summary) != 2) {
 ```
 
 
-```{r message-same-day-commit}
-#| results='asis'
-
-if (Sys.Date() %in% as.Date(hardware_summary$commit.timestamp)) {
-  ## fail early and informatively with when not using correct hardware
-  cat("**You are trying to examine commits that were made today. It is possible that not all benchmarks have been completed yet and plots below may show unexpected results. Setting `contender_git_commit` to 'latest completed' should find a suitable commit**")
-}
-```
 
 # Benchmark Run Summary
 ```{r table-run-summary}
@@ -140,6 +132,17 @@ hardware_summary %>%
   opt_table_font(font = google_font("Roboto Mono"))
 ```
 
+```{r message-same-day-commit}
+#| results: 'asis'
+
+# if (Sys.Date() %in% as.Date(hardware_summary$commit.timestamp)) {
+if (TRUE) {
+  ## fail early and informatively with when not using correct hardware
+  cat("::: {.callout-warning}\n")
+  cat("You are trying to examine commits that were made today. It is possible that not all benchmarks have been completed yet and plots below may show unexpected results.\n")
+  cat(":::\n")
+}
+```
 
 
 

--- a/performance-release-report/performance-release-report.qmd
+++ b/performance-release-report/performance-release-report.qmd
@@ -70,6 +70,8 @@ opts_chunk$set(
 
 baseline_git_commit_short <- substr(baseline_git_commit, 1, 7)
 contender_git_commit_short <- substr(contender_git_commit, 1, 7)
+
+source("R/functions.R")
 ```
 
 
@@ -77,35 +79,25 @@ contender_git_commit_short <- substr(contender_git_commit, 1, 7)
 #| include: false
 #| results: 'asis'
 
-runs_raw <- runs(c(baseline_git_commit, contender_git_commit)) 
+run_comp <- find_runs(baseline_git_commit, contender_git_commit, hardware_name)
 
-if (length(runs_raw) == 0) {
+if (length(run_comp) == 0) {
   knit_exit("No runs found for the given commits. Please check that the commits are correct and that the benchmark runs have completed.")
-} else {
-  run_comp <- runs_raw %>%
-    filter(hardware.name == hardware_name) %>%
-    mutate(run_type = case_when(
-      commit.sha == contender_git_commit ~ "contender",
-      commit.sha == baseline_git_commit ~ "baseline"
-    )) %>%
-    mutate(links.self = url_cleaner(links.self))
-
-  hardware_summary <- run_comp %>%
-    mutate(commit.timestamp = ymd_hms(commit.timestamp)) %>%
-    distinct(run_type, links.self, commit.sha, commit.timestamp, commit.url, hardware.cpu_model_name)
 }
 
-
+hardware_summary <- run_comp %>%
+  mutate(commit.timestamp = ymd_hms(commit.timestamp)) %>%
+  distinct(run_type, links.self, commit.sha, commit.timestamp, commit.url, hardware.cpu_model_name)
 ```
 
 
 ```{r message-missing-hardware}
 #| results: 'asis'
 
-if (nrow(hardware_summary) != 2) {
+if (nrow(hardware_summary) != 2L*length(hardware_name)) {
   ## fail early and informatively with when not using correct hardware
-  missing_commits <- setdiff(c(contender_git_commit, baseline_git_commit), hardware_summary$commit.sha)
-  cat(pluralize("Commit{?s} {missing_commits} w{?as/ere} not benchmarked with {hardware_name} hardware. This report only tests that hardware."))
+  missing_commits <- setdiff(c(contender_git_commit, baseline_git_commit), unique(hardware_summary$commit.sha)[1])
+  cat(pluralize("Commits {missing_commits} w{?as/ere} not benchmarked with {glue_collapse(hardware_name, last = ' & ')} hardware."))
   knit_exit()
 }
 ```
@@ -155,93 +147,17 @@ if (Sys.Date() %in% as.Date(hardware_summary$commit.timestamp)) {
 
 change_cols <- viridisLite::mako(2, begin = 0.5, end = 0.75)
 names(change_cols) <- c(glue("{contender_git_commit_short} (contender) faster"), glue("{baseline_git_commit_short} (baseline) faster"))
-
-
-plot_comparison <- function(plot_df, alpha = 0.7) {
-
-  ## Can be a uri as well
-  plot_df <- plot_df %>% 
-    mutate(dataset = case_when(
-      is.na(dataset) ~ dataset_uri,
-      TRUE ~ dataset
-    ))
-
-  tag_names <- unlist(plot_df$tags_used)
-  x_facets <- c("compression", "format", "file_type", "use_legacy_dataset")
-  # TODO: add others?
-  x_facets <- x_facets[x_facets %in% tag_names]
-
-  y_facets <- c("output_type", "input_type", "streaming", "pre_buffer", "async", "selectivity", "scale_factor")
-  y_facets <- y_facets[y_facets %in% tag_names]
-
-  maybe_vars <- function(variables) {
-    if (length(variables) == 0) {
-      return(NULL)
-    }
-
-    vars(!!!syms(variables))
-  }
-
-  title <- glue::glue("{unique(plot_df$language)}: {unique(plot_df$benchmark_name)}")
-
-  p <- plot_df %>%
-    mutate(change_lab = change * 1.05) %>%
-    ggplot() +
-    aes(y = forcats::fct_reorder(dataset, pn_lab, .desc = TRUE), x = change, fill = pn_lab) +
-    geom_col_interactive(
-      aes(
-        tooltip = glue(
-          "Percent change: {round(change, 2)}%\n",
-          "Difference: {difference}\n",
-          "Dataset: {dataset}"
-        )
-      ),
-      position = "dodge", alpha = 0.75, width = 0.75, colour = "grey 40"
-    ) +
-    geom_vline(xintercept = 0, colour = "grey50") +
-    geom_text(aes(x = change_lab, hjust = ifelse(change >= 0, 0, 1), label = difference, colour = pn_lab), size = 6) +
-    facet_grid(rows = maybe_vars(x_facets), cols = maybe_vars(y_facets), labeller = label_both) +
-    scale_fill_manual(values = change_cols) +
-    scale_colour_manual(values = change_cols) +
-    scale_x_continuous(expand = expansion(mult = 0.6)) +
-    guides(colour = "none") +
-    ylab("Dataset") +
-    xlab("% change")
-  
-  ## Some height adjustments
-  g_heights <- 6
-  g_widths <- 16
-
-  if (length(x_facets) > 0) {
-    g_heights <- g_heights*(n_distinct(plot_df[, x_facets, drop = TRUE])/1.25)
-  }
-  girafe(
-    ggobj = p,
-    options = list(
-      opts_tooltip(use_fill = TRUE),
-      opts_sizing(width = .7)
-    ),
-    width_svg = g_widths,
-    height_svg = g_heights
-  )
-}
 ```
 
 
 ```{r compute-process-data}
 #| results: 'asis'
 
-# grab the run comparison from the API
-conbench_df <- compare(
-  type = "runs",
-  run_comp$id[run_comp$run_type == "baseline"],
-  run_comp$id[run_comp$run_type == "contender"],
-  simplifyVector = TRUE
-) %>%
-  as_tibble()
-
-## which properties are guaranteed to be the same?
-conbench_df <- conbench_df %>%
+# Compare the baseline to the contender for 
+# macrobenchmarks
+macro_bm_df <- run_comp %>%
+  filter(hardware.name == "ursa-i9-9960x") %>%
+  compare_baseline_to_contender() %>%
   filter(baseline$language %in% c("Python", "R"))
 
 conbench_proced <- conbench_df %>%
@@ -256,50 +172,19 @@ conbench_proced <- conbench_df %>%
     TRUE ~ baseline_tags$dataset
   )) %>%
   group_by(baseline$language, baseline$benchmark_name) %>%
-  group_map(~ {
-    # only keep the tags that are not all NA
-    tags <- .x$baseline_tags[colSums(!is.na(.x$baseline_tags)) > 0]
+  group_map(~ tidy_compare(.x, .y))
 
-    if (length(unique(tags$name)) > 1) {
-      browser()
-    }
-
-    tag_names <- colnames(tags)
-    tag_names <- tag_names[!tag_names %in% c("name", "query_id", "language", "engine", "memory_map", "query", "async")]
-
-    plot_df <- .x %>%
-      jsonlite::flatten() %>%
-      as_tibble() %>%
-      select(-baseline_tags.dataset, -baseline_tags.language) %>%
-      rename_with(~ gsub("baseline_tags.", "", .)) %>%
-      mutate(change = analysis.pairwise.percent_change) %>%
-      #   mutate(across(c(baseline, contender), ~as.numeric(gsub("s", "", .x)))) %>%
-      mutate(difference = paste0(round((baseline.single_value_summary - contender.single_value_summary) * 1000, 4), " ms")) %>%
-      mutate(
-        pn_lab = case_when(
-          analysis.pairwise.percent_change == 0 ~ "no change",
-          analysis.pairwise.percent_change > 0 ~ paste0(contender_git_commit_short, " (contender) faster"),
-          analysis.pairwise.percent_change < 0 ~ paste0(baseline_git_commit_short, " (baseline) faster")
-        )
-      ) %>%
-      mutate(
-        tags_used = list(tag_names),
-        language = .y$`baseline$language`,
-        benchmark_name = .y$`baseline$benchmark_name`
-      )
-  })
-
-conbench_list <- list()
-for (i in seq_len(length(conbench_proced))) {
-  one_conbench <- conbench_proced[[i]]
+macro_bm_list <- list()
+for (i in seq_len(length(macro_bm_proced))) {
+  one_conbench <- macro_bm_proced[[i]]
   lang <- unique(one_conbench$language)
   benchmark_name <- unique(one_conbench$benchmark_name)
-  conbench_list[[lang]][[benchmark_name]] <- one_conbench
+  macro_bm_list[[lang]][[benchmark_name]] <- one_conbench
 }
 
-tpch_data <- conbench_list[["R"]][["tpch"]]
+tpch_data <- macro_bm_list[["R"]][["tpch"]]
 
-conbench_list[["R"]][which(names(conbench_list[["R"]]) %in% c("tpch"))] <- NULL
+macro_bm_list[["R"]][which(names(macro_bm_list[["R"]]) %in% c("tpch"))] <- NULL
 ```
 
 ## Python
@@ -308,15 +193,15 @@ conbench_list[["R"]][which(names(conbench_list[["R"]]) %in% c("tpch"))] <- NULL
 #| results: 'asis'
 #| warning: FALSE
  
-#names(conbench_list)
+#names(macro_bm_list)
 lang <- "Python"
-python_plots <- map_chr(names(conbench_list[[lang]]), \(bm_name) {
+python_plots <- map_chr(names(macro_bm_list[[lang]]), \(bm_name) {
   knit_child(
     text = c(
       '```{r}',
       "#| results: 'asis'",
       'cat("###", bm_name, "\n")',
-      'plot_comparison(conbench_list[[lang]][[bm_name]])',
+      'plot_comparison(macro_bm_list[[lang]][[bm_name]])',
       '```'
     ),
     envir = environment(),
@@ -335,13 +220,13 @@ cat(python_plots, sep = "\n")
 #| warning: FALSE
  
 lang <- "R"
-r_plots <- map_chr(names(conbench_list[[lang]]), \(bm_name) {
+r_plots <- map_chr(names(macro_bm_list[[lang]]), \(bm_name) {
   knit_child(
     text = c(
       '```{r}',
       "#| results: 'asis'",
       'cat("###", bm_name, "\n")',
-      'plot_comparison(conbench_list[[lang]][[bm_name]])',
+      'plot_comparison(macro_bm_list[[lang]][[bm_name]])',
       '```'
     ),
     envir = environment(),
@@ -392,6 +277,29 @@ girafe(
   width_svg = 16,
   height_svg = 20
 )
+```
+
+
+## Microbenchmarks
+
+Float regressions to the top
+
+```{r compute-process-micro-bm-data}
+#| cache: !expr '!is_gha()'
+
+micro_bm_df <- run_comp %>%
+  filter(hardware.name == "ursa-thinkcentre-m75q") %>%
+  compare_baseline_to_contender()
+
+## unlike the plots above, this is added as single rectangular
+## data.frame because that data structure is easier to work with
+## using arquero
+micro_bm_proced <- micro_bm_df %>%
+  mutate(baseline_tags = baseline$tags) %>%
+  group_by(baseline$language, baseline$benchmark_name) %>%
+  group_modify(~ tidy_compare(.x, .y)) %>% 
+  ungroup() %>% 
+  filter(!is.na(name))
 ```
 
 

--- a/performance-release-report/performance-release-report.qmd
+++ b/performance-release-report/performance-release-report.qmd
@@ -166,6 +166,10 @@ run_summary %>%
     languages = "Languages",
     n_benchmarks = "Number of Benchmarks"
   ) %>% 
+  tab_footnote(
+    "When we compare benchmark results, we always have a contender (the new code that we are considering) and a baseline (the old code that were are comparing to). The historic distribution will be drawn from all benchmark results on commits in the baseline commit's git ancestry, up to and including all runs on the baseline commit itself. In this context, a baseline is typically the last Arrow release and the contender is the current release candidate.",
+    locations = cells_column_labels(columns = "run_type")
+  ) %>% 
   opt_table_font(font = google_font("Roboto Mono"))
 ```
 

--- a/performance-release-report/performance-release-report.qmd
+++ b/performance-release-report/performance-release-report.qmd
@@ -323,29 +323,30 @@ micro_bm_proced <- micro_bm_df %>%
   ungroup() %>% 
   filter(!is.na(name)) %>% 
   clean_names() %>% 
-  select(language, baseline_benchmark_name, name, params, suite, analysis_pairwise_regression_indicated, analysis_pairwise_improvement_indicated, change, difference, pn_lab, analysis_lookback_z_score_z_score)
+  select(language, baseline_benchmark_name, name, params, suite, analysis_pairwise_regression_indicated, analysis_pairwise_improvement_indicated, change, difference, pn_lab, analysis_lookback_z_score_z_score, analysis_lookback_z_score_z_threshold)
 ```
 
 There are currently `r nrow(micro_bm_proced)` microbenchmarks in the Arrow benchmarks. The following comparisons are also available to be viewed in the [Conbench UI](`r generate_compare_url(micro_bm_df)`). 
 
 ```{r table-micro-bm-summary}
+threshold <- unique(micro_bm_proced$analysis_lookback_z_score_z_threshold)
 micro_bm_proced %>% 
   count(language, analysis_pairwise_regression_indicated, analysis_pairwise_improvement_indicated) %>% 
   mutate(col_var = case_when(
     analysis_pairwise_regression_indicated == TRUE ~ "Regressions",
     analysis_pairwise_improvement_indicated == TRUE ~ "Improvements",
-    TRUE ~ "Neither"
+    TRUE ~ "Stable"
   )) %>%
-  select(-all_of(starts_with("analysis"))) %>% 
+  select(-all_of(starts_with("analysis_pairwise"))) %>% 
   pivot_wider(names_from = col_var, values_from = n) %>% 
   rowwise() %>%
-  mutate(Total = sum(c_across(c(Neither, Improvements, Regressions)))) %>%
-  select(-Neither) %>%
+  mutate(Total = sum(c_across(c(Stable, Improvements, Regressions)))) %>%
+  mutate(`z-score threshold` = threshold, .after = language) %>% 
   gt() %>% 
   cols_label(language = "Language") %>% 
   tab_spanner(
     label = "Number of microbenchmarks",
-    columns = c(Improvements, Regressions, Total)
+    columns = c(Stable, Improvements, Regressions, Total)
   ) %>%
   opt_table_font(font = google_font("Roboto Mono"))
 ```

--- a/performance-release-report/performance-release-report.qmd
+++ b/performance-release-report/performance-release-report.qmd
@@ -226,11 +226,11 @@ lang <- "Python"
 python_plots <- map_chr(names(macro_bm_list[[lang]]), \(bm_name) {
   knit_child(
     text = c(
-      '```{r}',
+      glue("```{r plot-<<lang>>-<<bm_name>>}", .open = "<<", .close = ">>"),
       "#| results: 'asis'",
       'cat("###", bm_name, "\n")',
-      'plot_comparison(macro_bm_list[[lang]][[bm_name]])',
-      '```'
+      "plot_comparison(macro_bm_list[[lang]][[bm_name]])",
+      "```"
     ),
     envir = environment(),
     quiet = TRUE
@@ -251,11 +251,11 @@ lang <- "R"
 r_plots <- map_chr(names(macro_bm_list[[lang]]), \(bm_name) {
   knit_child(
     text = c(
-      '```{r}',
+      glue("```{r plot-<<lang>>-<<bm_name>>}", .open = "<<", .close = ">>"),
       "#| results: 'asis'",
       'cat("###", bm_name, "\n")',
-      'plot_comparison(macro_bm_list[[lang]][[bm_name]])',
-      '```'
+      "plot_comparison(macro_bm_list[[lang]][[bm_name]])",
+      "```"
     ),
     envir = environment(),
     quiet = TRUE
@@ -328,7 +328,7 @@ micro_bm_proced <- micro_bm_df %>%
 
 There are currently `r nrow(micro_bm_proced)` microbenchmarks in the Arrow benchmarks. The following comparisons are also available to be viewed in the [Conbench UI](`r generate_compare_url(micro_bm_df)`). 
 
-```{r}
+```{r table-micro-bm-summary}
 micro_bm_proced %>% 
   count(language, analysis_pairwise_regression_indicated, analysis_pairwise_improvement_indicated) %>% 
   mutate(col_var = case_when(
@@ -356,7 +356,7 @@ Because of the large number of benchmarks, the top 20 benchmark results that dev
 
 ## Top 20 negative z-scores
 
-```{r}
+```{r table-top-zscores-negative}
 top_zscore_table(micro_bm_proced, direction = "negative")
 ```
 
@@ -367,7 +367,7 @@ top_zscore_table(micro_bm_proced, direction = "negative")
 
 ## Top 20 positive z-scores
 
-```{r}
+```{r table-top-zscores-positive}
 top_zscore_table(micro_bm_proced, direction = "positive")
 ```
 

--- a/performance-release-report/performance-release-report.qmd
+++ b/performance-release-report/performance-release-report.qmd
@@ -323,7 +323,7 @@ micro_bm_proced <- micro_bm_df %>%
   ungroup() %>% 
   filter(!is.na(name)) %>% 
   clean_names() %>% 
-  select(language, baseline_benchmark_name, name, params, suite, analysis_pairwise_regression_indicated, analysis_pairwise_improvement_indicated, change, difference, pn_lab, analysis_lookback_z_score_z_score, analysis_lookback_z_score_z_threshold)
+  select(language, baseline_benchmark_name, name, params, suite, analysis_pairwise_regression_indicated, analysis_pairwise_improvement_indicated, change, difference, pn_lab, analysis_lookback_z_score_z_score, analysis_lookback_z_score_z_threshold, baseline_single_value_summary, contender_single_value_summary)
 ```
 
 There are currently `r nrow(micro_bm_proced)` microbenchmarks in the Arrow benchmarks. The following comparisons are also available to be viewed in the [Conbench UI](`r generate_compare_url(micro_bm_df)`). 
@@ -355,10 +355,10 @@ Because of the large number of benchmarks, the top 20 benchmark results that dev
 
 ::: {.callout-important collapse="true"}
 
-## Top 20 negative z-scores
+## Largest 20 regressions between baseline and contender
 
 ```{r table-top-zscores-negative}
-top_zscore_table(micro_bm_proced, direction = "negative")
+top_zscore_table(micro_bm_proced, direction = "regression")
 ```
 
 
@@ -366,10 +366,10 @@ top_zscore_table(micro_bm_proced, direction = "negative")
 
 ::: {.callout-note collapse="true"}
 
-## Top 20 positive z-scores
+## Largest 20 improvements between baseline and contender
 
 ```{r table-top-zscores-positive}
-top_zscore_table(micro_bm_proced, direction = "positive")
+top_zscore_table(micro_bm_proced, direction = "improvement")
 ```
 
 :::

--- a/performance-release-report/performance-release-report.qmd
+++ b/performance-release-report/performance-release-report.qmd
@@ -428,14 +428,13 @@ microBmProced = aq.from(transpose(ojs_micro_bm_proced))
 
 ## Microbenchmark explorer {#micro-bm-explorer}
 
-Formal pairwise comparisons between the baseline and contender can further be broken down below by language, suite, and benchmark name. Additionally regressions and improvements can be filtered to show only those detected as a threshold level of `r threshold` z-scores.
-
+This microbenchmarks explorer allows you to filter the microbenchmark results by language, suite, and benchmark name and toggle regressions and improvements based on a threshold level of `r threshold` z-scores. Languages, suite and benchmark name default to showing all results for that category. The display can be further filtered by selecting a specific language, suite, or benchmark name. Each bar can be clicked to open the Conbench UI page for that benchmark providing additional history and metadata.
 
 ```{ojs filter-micro-bm}
 // Top level: are there regressions/improvements?
 viewof changes = Inputs.checkbox(["Regressions", "Improvements"], {
   label: md`**Benchmark Status**`,
-  value: "Regressions"
+  value: ["Regressions"]
   })
 
 // Choose the state of the benchmark
@@ -461,41 +460,51 @@ microBmProcedChanges = {
 }
 
 // Choose the language
-allLanguageValues = microBmProcedChanges.dedupe('language').array('language')
+allLanguageValues = ["All languages"].concat(microBmProcedChanges.dedupe('language').array('language'))
 
 viewof languageSelected = Inputs.select(allLanguageValues, {
     label: md`**Language**`,
-    value: ["All languages"].concat([allLanguageValues[0]]),
+    value: [allLanguageValues[0]],
     width: boxWidth
 })
 
-// Choose the suite
-allSuiteValues = microBmProcedChanges
-    .filter(aq.escape(d => op.equal(d.language, languageSelected)))
-    .dedupe('suite').array('suite')
+languages = {
+  return (languageSelected === "All languages")
+  ? microBmProcedChanges // If languageSelected is "All languages", no filtering is applied
+  : microBmProcedChanges.filter(aq.escape(d => op.includes(d.language, languageSelected)));
+}
 
+
+allSuiteValues = ["All suites"].concat(languages.dedupe('suite').array('suite'))
+
+// Choose the suite
 viewof suiteSelected = Inputs.select(allSuiteValues, {
     label: md`**Suite**`,
     value: [allSuiteValues[0]],
     width: boxWidth
 })
 
-// Choose the benchmark
-allNameValues = microBmProcedChanges
-    .filter(aq.escape(d => op.equal(d.language, languageSelected)))
-    .filter(aq.escape(d => op.equal(d.suite, suiteSelected)))
-    .dedupe('name').array('name')
 
+suites = {
+  return (suiteSelected === "All suites")
+  ? languages 
+  : languages.filter(aq.escape(d => op.includes(d.suite, suiteSelected)));
+}
+
+allNameValues = ["All benchmarks"].concat(suites.dedupe('name').array('name'))
+
+// Choose the benchmark
 viewof nameSelected = Inputs.select(allNameValues, {
-    label: md`**Name**`,
+    label: md`**Benchmark Name**`,
     value: [allNameValues[0]],
     width: boxWidth
 })
 
-microBmProcedChangesFiltered = microBmProcedChanges
-    .filter(aq.escape(d => op.equal(d.language, languageSelected)))
-    .filter(aq.escape(d => op.equal(d.suite, suiteSelected)))
-    .filter(aq.escape(d => op.equal(d.name, nameSelected)))
+microBmProcedChangesFiltered = {
+  return (nameSelected === "All benchmarks")
+  ? suites 
+  : suites.filter(aq.escape(d => op.includes(d.name, nameSelected)));
+}
 ```
 
 ```{ojs plot-micro-bm}

--- a/performance-release-report/renv.lock
+++ b/performance-release-report/renv.lock
@@ -30,12 +30,11 @@
     },
     "Matrix": {
       "Package": "Matrix",
-      "Version": "1.6-1",
+      "Version": "1.5-4.1",
       "Source": "Repository",
-      "Repository": "RSPM",
+      "Repository": "CRAN",
       "Requirements": [
         "R",
-        "grDevices",
         "graphics",
         "grid",
         "lattice",
@@ -43,13 +42,13 @@
         "stats",
         "utils"
       ],
-      "Hash": "cb6855ac711958ca734b75e631b2035d"
+      "Hash": "38082d362d317745fb932e13956dccbb"
     },
     "R6": {
       "Package": "R6",
       "Version": "2.5.1",
       "Source": "Repository",
-      "Repository": "CRAN",
+      "Repository": "RSPM",
       "Requirements": [
         "R"
       ],
@@ -67,37 +66,37 @@
     },
     "Rcpp": {
       "Package": "Rcpp",
-      "Version": "1.0.11",
+      "Version": "1.0.10",
       "Source": "Repository",
       "Repository": "RSPM",
       "Requirements": [
         "methods",
         "utils"
       ],
-      "Hash": "ae6cbbe1492f4de79c45fce06f967ce8"
+      "Hash": "e749cae40fa9ef469b6050959517453c"
     },
     "V8": {
       "Package": "V8",
-      "Version": "4.3.3",
+      "Version": "4.3.0",
       "Source": "Repository",
-      "Repository": "RSPM",
+      "Repository": "CRAN",
       "Requirements": [
         "Rcpp",
         "curl",
         "jsonlite",
         "utils"
       ],
-      "Hash": "20d81ec18bde233d8cc3265761fe8c93"
+      "Hash": "d1fa8fae6a47e88bb46d5152312bd8bd"
     },
     "askpass": {
       "Package": "askpass",
-      "Version": "1.2.0",
+      "Version": "1.1",
       "Source": "Repository",
       "Repository": "RSPM",
       "Requirements": [
         "sys"
       ],
-      "Hash": "cad6cf7f1d5f6e906700b9d3e718c796"
+      "Hash": "e8a22846fff485f0be3770c2da758713"
     },
     "base64enc": {
       "Package": "base64enc",
@@ -128,7 +127,7 @@
     },
     "bslib": {
       "Package": "bslib",
-      "Version": "0.5.1",
+      "Version": "0.4.2",
       "Source": "Repository",
       "Repository": "RSPM",
       "Requirements": [
@@ -144,7 +143,7 @@
         "rlang",
         "sass"
       ],
-      "Hash": "283015ddfbb9d7bf15ea9f0b5698f0d9"
+      "Hash": "a7fbf03946ad741129dc81098722fca1"
     },
     "cachem": {
       "Package": "cachem",
@@ -186,7 +185,7 @@
       "Package": "commonmark",
       "Version": "1.9.0",
       "Source": "Repository",
-      "Repository": "CRAN",
+      "Repository": "RSPM",
       "Hash": "d691c61bff84bd63c383874d2d0c3307"
     },
     "conbenchcoms": {
@@ -209,38 +208,35 @@
     },
     "cpp11": {
       "Package": "cpp11",
-      "Version": "0.4.6",
+      "Version": "0.4.3",
       "Source": "Repository",
-      "Repository": "CRAN",
-      "Requirements": [
-        "R"
-      ],
-      "Hash": "707fae4bbf73697ec8d85f9d7076c061"
+      "Repository": "RSPM",
+      "Hash": "ed588261931ee3be2c700d22e94a29ab"
     },
     "curl": {
       "Package": "curl",
-      "Version": "5.0.2",
+      "Version": "5.0.0",
       "Source": "Repository",
-      "Repository": "CRAN",
+      "Repository": "RSPM",
       "Requirements": [
         "R"
       ],
-      "Hash": "511bacbfa153a15251166b463b4da4f9"
+      "Hash": "e4f97056611e8e6b8b852d13b7400cf1"
     },
     "digest": {
       "Package": "digest",
-      "Version": "0.6.33",
+      "Version": "0.6.31",
       "Source": "Repository",
-      "Repository": "CRAN",
+      "Repository": "RSPM",
       "Requirements": [
         "R",
         "utils"
       ],
-      "Hash": "b18a9cf3c003977b0cc49d5e76ebe48d"
+      "Hash": "8b708f296afd9ae69f450f9640be8990"
     },
     "dplyr": {
       "Package": "dplyr",
-      "Version": "1.1.3",
+      "Version": "1.1.2",
       "Source": "Repository",
       "Repository": "RSPM",
       "Requirements": [
@@ -259,7 +255,7 @@
         "utils",
         "vctrs"
       ],
-      "Hash": "e85ffbebaad5f70e1a2e2ef4302b4949"
+      "Hash": "dea6970ff715ca541c387de363ff405e"
     },
     "ellipsis": {
       "Package": "ellipsis",
@@ -311,7 +307,7 @@
     },
     "fontawesome": {
       "Package": "fontawesome",
-      "Version": "0.5.2",
+      "Version": "0.5.1",
       "Source": "Repository",
       "Repository": "RSPM",
       "Requirements": [
@@ -319,7 +315,7 @@
         "htmltools",
         "rlang"
       ],
-      "Hash": "c2efdd5f0bcd1ea861c2d4e2a883a67d"
+      "Hash": "1e22b8cabbad1eae951a75e9f8b52378"
     },
     "forcats": {
       "Package": "forcats",
@@ -339,14 +335,14 @@
     },
     "fs": {
       "Package": "fs",
-      "Version": "1.6.3",
+      "Version": "1.6.2",
       "Source": "Repository",
-      "Repository": "CRAN",
+      "Repository": "RSPM",
       "Requirements": [
         "R",
         "methods"
       ],
-      "Hash": "47b5f30c720c23999b913a1a635cf0bb"
+      "Hash": "94af08e0aa9675a16fadbb3aaaa90d2a"
     },
     "generics": {
       "Package": "generics",
@@ -381,7 +377,7 @@
     },
     "ggplot2": {
       "Package": "ggplot2",
-      "Version": "3.4.3",
+      "Version": "3.4.2",
       "Source": "Repository",
       "Repository": "RSPM",
       "Requirements": [
@@ -402,7 +398,7 @@
         "vctrs",
         "withr"
       ],
-      "Hash": "85846544c596e71f8f46483ab165da33"
+      "Hash": "3a147ee02e85a8941aad9909f1b43b7b"
     },
     "glue": {
       "Package": "glue",
@@ -447,7 +443,7 @@
     },
     "gtable": {
       "Package": "gtable",
-      "Version": "0.3.4",
+      "Version": "0.3.3",
       "Source": "Repository",
       "Repository": "RSPM",
       "Requirements": [
@@ -458,7 +454,7 @@
         "lifecycle",
         "rlang"
       ],
-      "Hash": "b29cf3031f49b04ab9c852c912547eef"
+      "Hash": "b44addadb528a0d227794121c00572a0"
     },
     "highr": {
       "Package": "highr",
@@ -487,7 +483,7 @@
     },
     "htmltools": {
       "Package": "htmltools",
-      "Version": "0.5.6",
+      "Version": "0.5.5",
       "Source": "Repository",
       "Repository": "RSPM",
       "Requirements": [
@@ -500,7 +496,7 @@
         "rlang",
         "utils"
       ],
-      "Hash": "a2326a66919a3311f7fbb1e3bf568283"
+      "Hash": "ba0240784ad50a62165058a27459304a"
     },
     "htmlwidgets": {
       "Package": "htmlwidgets",
@@ -521,7 +517,7 @@
       "Package": "httr2",
       "Version": "0.2.3",
       "Source": "Repository",
-      "Repository": "CRAN",
+      "Repository": "RSPM",
       "Requirements": [
         "R",
         "R6",
@@ -581,13 +577,13 @@
     },
     "jsonlite": {
       "Package": "jsonlite",
-      "Version": "1.8.7",
+      "Version": "1.8.4",
       "Source": "Repository",
-      "Repository": "CRAN",
+      "Repository": "RSPM",
       "Requirements": [
         "methods"
       ],
-      "Hash": "266a20443ca13c65688b2116d5220f76"
+      "Hash": "a4269a09a9b865579b2635c77e572374"
     },
     "juicyjuice": {
       "Package": "juicyjuice",
@@ -601,7 +597,7 @@
     },
     "knitr": {
       "Package": "knitr",
-      "Version": "1.43",
+      "Version": "1.42",
       "Source": "Repository",
       "Repository": "CRAN",
       "Requirements": [
@@ -613,18 +609,18 @@
         "xfun",
         "yaml"
       ],
-      "Hash": "9775eb076713f627c07ce41d8199d8f6"
+      "Hash": "8329a9bcc82943c8069104d4be3ee22d"
     },
     "labeling": {
       "Package": "labeling",
-      "Version": "0.4.3",
+      "Version": "0.4.2",
       "Source": "Repository",
       "Repository": "RSPM",
       "Requirements": [
         "graphics",
         "stats"
       ],
-      "Hash": "b64ec208ac5bc1852b285f665d6368b3"
+      "Hash": "3d5108641f47470611a32d0bdf357a72"
     },
     "lattice": {
       "Package": "lattice",
@@ -679,16 +675,16 @@
     },
     "markdown": {
       "Package": "markdown",
-      "Version": "1.8",
+      "Version": "1.7",
       "Source": "Repository",
-      "Repository": "RSPM",
+      "Repository": "CRAN",
       "Requirements": [
         "R",
         "commonmark",
         "utils",
         "xfun"
       ],
-      "Hash": "93cecf1e5f828d0fc1605a00ad48e3a2"
+      "Hash": "0ffaea87c070a56d140ce00b0727b278"
     },
     "memoise": {
       "Package": "memoise",
@@ -703,9 +699,9 @@
     },
     "mgcv": {
       "Package": "mgcv",
-      "Version": "1.9-0",
+      "Version": "1.8-42",
       "Source": "Repository",
-      "Repository": "RSPM",
+      "Repository": "CRAN",
       "Requirements": [
         "Matrix",
         "R",
@@ -716,7 +712,7 @@
         "stats",
         "utils"
       ],
-      "Hash": "086028ca0460d0c368028d3bda58f31b"
+      "Hash": "3460beba7ccc8946249ba35327ba902a"
     },
     "mime": {
       "Package": "mime",
@@ -741,9 +737,9 @@
     },
     "nlme": {
       "Package": "nlme",
-      "Version": "3.1-163",
+      "Version": "3.1-162",
       "Source": "Repository",
-      "Repository": "RSPM",
+      "Repository": "CRAN",
       "Requirements": [
         "R",
         "graphics",
@@ -751,17 +747,17 @@
         "stats",
         "utils"
       ],
-      "Hash": "8d1938040a05566f4f7a14af4feadd6b"
+      "Hash": "0984ce8da8da9ead8643c5cbbb60f83e"
     },
     "openssl": {
       "Package": "openssl",
-      "Version": "2.1.0",
+      "Version": "2.0.6",
       "Source": "Repository",
-      "Repository": "CRAN",
+      "Repository": "RSPM",
       "Requirements": [
         "askpass"
       ],
-      "Hash": "273a6bb4a9844c296a459d2176673270"
+      "Hash": "0f7cd2962e3044bb940cca4f4b5cecbe"
     },
     "pillar": {
       "Package": "pillar",
@@ -792,9 +788,9 @@
     },
     "purrr": {
       "Package": "purrr",
-      "Version": "1.0.2",
+      "Version": "1.0.1",
       "Source": "Repository",
-      "Repository": "CRAN",
+      "Repository": "RSPM",
       "Requirements": [
         "R",
         "cli",
@@ -803,13 +799,13 @@
         "rlang",
         "vctrs"
       ],
-      "Hash": "1cba04a4e9414bdefc9dcaa99649a8dc"
+      "Hash": "d71c815267c640f17ddbf7f16144b4bb"
     },
     "rappdirs": {
       "Package": "rappdirs",
       "Version": "0.3.3",
       "Source": "Repository",
-      "Repository": "CRAN",
+      "Repository": "RSPM",
       "Requirements": [
         "R"
       ],
@@ -844,7 +840,7 @@
       "Package": "renv",
       "Version": "1.0.2",
       "Source": "Repository",
-      "Repository": "RSPM",
+      "Repository": "CRAN",
       "Requirements": [
         "utils"
       ],
@@ -863,7 +859,7 @@
     },
     "rmarkdown": {
       "Package": "rmarkdown",
-      "Version": "2.24",
+      "Version": "2.21",
       "Source": "Repository",
       "Repository": "RSPM",
       "Requirements": [
@@ -883,11 +879,11 @@
         "xfun",
         "yaml"
       ],
-      "Hash": "3854c37590717c08c32ec8542a2e0a35"
+      "Hash": "493df4ae51e2e984952ea4d5c75786a3"
     },
     "sass": {
       "Package": "sass",
-      "Version": "0.4.7",
+      "Version": "0.4.6",
       "Source": "Repository",
       "Repository": "RSPM",
       "Requirements": [
@@ -897,7 +893,7 @@
         "rappdirs",
         "rlang"
       ],
-      "Hash": "6bd4d33b50ff927191ec9acbf52fd056"
+      "Hash": "cc3ec7dd33982ef56570229b62d6388e"
     },
     "scales": {
       "Package": "scales",
@@ -942,7 +938,7 @@
     },
     "snakecase": {
       "Package": "snakecase",
-      "Version": "0.11.1",
+      "Version": "0.11.0",
       "Source": "Repository",
       "Repository": "CRAN",
       "Requirements": [
@@ -950,13 +946,13 @@
         "stringi",
         "stringr"
       ],
-      "Hash": "58767e44739b76965332e8a4fe3f91f1"
+      "Hash": "4079070fc210c7901c0832a3aeab894f"
     },
     "stringi": {
       "Package": "stringi",
       "Version": "1.7.12",
       "Source": "Repository",
-      "Repository": "CRAN",
+      "Repository": "RSPM",
       "Requirements": [
         "R",
         "stats",
@@ -969,7 +965,7 @@
       "Package": "stringr",
       "Version": "1.5.0",
       "Source": "Repository",
-      "Repository": "CRAN",
+      "Repository": "RSPM",
       "Requirements": [
         "R",
         "cli",
@@ -986,7 +982,7 @@
       "Package": "sys",
       "Version": "3.4.2",
       "Source": "Repository",
-      "Repository": "CRAN",
+      "Repository": "RSPM",
       "Hash": "3a1be13d68d47a8cd0bfd74739ca1555"
     },
     "sysfonts": {
@@ -1078,13 +1074,13 @@
     },
     "tinytex": {
       "Package": "tinytex",
-      "Version": "0.46",
+      "Version": "0.45",
       "Source": "Repository",
       "Repository": "RSPM",
       "Requirements": [
         "xfun"
       ],
-      "Hash": "0c41a73214d982f539c56a7773c7afa5"
+      "Hash": "e4e357f28c2edff493936b6cb30c3d65"
     },
     "utf8": {
       "Package": "utf8",
@@ -1098,19 +1094,19 @@
     },
     "uuid": {
       "Package": "uuid",
-      "Version": "1.1-1",
+      "Version": "1.1-0",
       "Source": "Repository",
-      "Repository": "RSPM",
+      "Repository": "CRAN",
       "Requirements": [
         "R"
       ],
-      "Hash": "3d78edfb977a69fc7a0341bee25e163f"
+      "Hash": "f1cb46c157d080b729159d407be83496"
     },
     "vctrs": {
       "Package": "vctrs",
-      "Version": "0.6.3",
+      "Version": "0.6.2",
       "Source": "Repository",
-      "Repository": "CRAN",
+      "Repository": "RSPM",
       "Requirements": [
         "R",
         "cli",
@@ -1118,7 +1114,7 @@
         "lifecycle",
         "rlang"
       ],
-      "Hash": "d0ef2856b83dc33ea6e255caf6229ee2"
+      "Hash": "a745bda7aff4734c17294bb41d4e4607"
     },
     "viridisLite": {
       "Package": "viridisLite",
@@ -1134,7 +1130,7 @@
       "Package": "withr",
       "Version": "2.5.0",
       "Source": "Repository",
-      "Repository": "CRAN",
+      "Repository": "RSPM",
       "Requirements": [
         "R",
         "grDevices",
@@ -1145,25 +1141,25 @@
     },
     "xfun": {
       "Package": "xfun",
-      "Version": "0.40",
+      "Version": "0.39",
       "Source": "Repository",
-      "Repository": "CRAN",
+      "Repository": "RSPM",
       "Requirements": [
         "stats",
         "tools"
       ],
-      "Hash": "be07d23211245fc7d4209f54c4e4ffc8"
+      "Hash": "8f56e9acb54fb525e66464d57ab58bcb"
     },
     "xml2": {
       "Package": "xml2",
-      "Version": "1.3.5",
+      "Version": "1.3.4",
       "Source": "Repository",
       "Repository": "CRAN",
       "Requirements": [
         "R",
         "methods"
       ],
-      "Hash": "6c40e5cfcc6aefd88110666e18c31f40"
+      "Hash": "7dc765ac9b909487326a7d471fdd3821"
     },
     "yaml": {
       "Package": "yaml",

--- a/performance-release-report/renv.lock
+++ b/performance-release-report/renv.lock
@@ -48,7 +48,7 @@
       "Package": "R6",
       "Version": "2.5.1",
       "Source": "Repository",
-      "Repository": "RSPM",
+      "Repository": "CRAN",
       "Requirements": [
         "R"
       ],
@@ -92,7 +92,7 @@
       "Package": "askpass",
       "Version": "1.1",
       "Source": "Repository",
-      "Repository": "RSPM",
+      "Repository": "CRAN",
       "Requirements": [
         "sys"
       ],
@@ -185,7 +185,7 @@
       "Package": "commonmark",
       "Version": "1.9.0",
       "Source": "Repository",
-      "Repository": "RSPM",
+      "Repository": "CRAN",
       "Hash": "d691c61bff84bd63c383874d2d0c3307"
     },
     "conbenchcoms": {
@@ -208,31 +208,34 @@
     },
     "cpp11": {
       "Package": "cpp11",
-      "Version": "0.4.3",
+      "Version": "0.4.6",
       "Source": "Repository",
-      "Repository": "RSPM",
-      "Hash": "ed588261931ee3be2c700d22e94a29ab"
-    },
-    "curl": {
-      "Package": "curl",
-      "Version": "5.0.0",
-      "Source": "Repository",
-      "Repository": "RSPM",
+      "Repository": "CRAN",
       "Requirements": [
         "R"
       ],
-      "Hash": "e4f97056611e8e6b8b852d13b7400cf1"
+      "Hash": "707fae4bbf73697ec8d85f9d7076c061"
+    },
+    "curl": {
+      "Package": "curl",
+      "Version": "5.0.2",
+      "Source": "Repository",
+      "Repository": "CRAN",
+      "Requirements": [
+        "R"
+      ],
+      "Hash": "511bacbfa153a15251166b463b4da4f9"
     },
     "digest": {
       "Package": "digest",
-      "Version": "0.6.31",
+      "Version": "0.6.33",
       "Source": "Repository",
-      "Repository": "RSPM",
+      "Repository": "CRAN",
       "Requirements": [
         "R",
         "utils"
       ],
-      "Hash": "8b708f296afd9ae69f450f9640be8990"
+      "Hash": "b18a9cf3c003977b0cc49d5e76ebe48d"
     },
     "dplyr": {
       "Package": "dplyr",
@@ -335,14 +338,14 @@
     },
     "fs": {
       "Package": "fs",
-      "Version": "1.6.2",
+      "Version": "1.6.3",
       "Source": "Repository",
-      "Repository": "RSPM",
+      "Repository": "CRAN",
       "Requirements": [
         "R",
         "methods"
       ],
-      "Hash": "94af08e0aa9675a16fadbb3aaaa90d2a"
+      "Hash": "47b5f30c720c23999b913a1a635cf0bb"
     },
     "generics": {
       "Package": "generics",
@@ -503,7 +506,7 @@
       "Package": "httr2",
       "Version": "0.2.3",
       "Source": "Repository",
-      "Repository": "RSPM",
+      "Repository": "CRAN",
       "Requirements": [
         "R",
         "R6",
@@ -541,13 +544,13 @@
     },
     "jsonlite": {
       "Package": "jsonlite",
-      "Version": "1.8.4",
+      "Version": "1.8.7",
       "Source": "Repository",
-      "Repository": "RSPM",
+      "Repository": "CRAN",
       "Requirements": [
         "methods"
       ],
-      "Hash": "a4269a09a9b865579b2635c77e572374"
+      "Hash": "266a20443ca13c65688b2116d5220f76"
     },
     "juicyjuice": {
       "Package": "juicyjuice",
@@ -561,7 +564,7 @@
     },
     "knitr": {
       "Package": "knitr",
-      "Version": "1.42",
+      "Version": "1.43",
       "Source": "Repository",
       "Repository": "CRAN",
       "Requirements": [
@@ -573,7 +576,7 @@
         "xfun",
         "yaml"
       ],
-      "Hash": "8329a9bcc82943c8069104d4be3ee22d"
+      "Hash": "9775eb076713f627c07ce41d8199d8f6"
     },
     "labeling": {
       "Package": "labeling",
@@ -715,13 +718,13 @@
     },
     "openssl": {
       "Package": "openssl",
-      "Version": "2.0.6",
+      "Version": "2.1.0",
       "Source": "Repository",
-      "Repository": "RSPM",
+      "Repository": "CRAN",
       "Requirements": [
         "askpass"
       ],
-      "Hash": "0f7cd2962e3044bb940cca4f4b5cecbe"
+      "Hash": "273a6bb4a9844c296a459d2176673270"
     },
     "pillar": {
       "Package": "pillar",
@@ -752,9 +755,9 @@
     },
     "purrr": {
       "Package": "purrr",
-      "Version": "1.0.1",
+      "Version": "1.0.2",
       "Source": "Repository",
-      "Repository": "RSPM",
+      "Repository": "CRAN",
       "Requirements": [
         "R",
         "cli",
@@ -763,13 +766,13 @@
         "rlang",
         "vctrs"
       ],
-      "Hash": "d71c815267c640f17ddbf7f16144b4bb"
+      "Hash": "1cba04a4e9414bdefc9dcaa99649a8dc"
     },
     "rappdirs": {
       "Package": "rappdirs",
       "Version": "0.3.3",
       "Source": "Repository",
-      "Repository": "RSPM",
+      "Repository": "CRAN",
       "Requirements": [
         "R"
       ],
@@ -904,7 +907,7 @@
       "Package": "stringi",
       "Version": "1.7.12",
       "Source": "Repository",
-      "Repository": "RSPM",
+      "Repository": "CRAN",
       "Requirements": [
         "R",
         "stats",
@@ -917,7 +920,7 @@
       "Package": "stringr",
       "Version": "1.5.0",
       "Source": "Repository",
-      "Repository": "RSPM",
+      "Repository": "CRAN",
       "Requirements": [
         "R",
         "cli",
@@ -934,7 +937,7 @@
       "Package": "sys",
       "Version": "3.4.2",
       "Source": "Repository",
-      "Repository": "RSPM",
+      "Repository": "CRAN",
       "Hash": "3a1be13d68d47a8cd0bfd74739ca1555"
     },
     "sysfonts": {
@@ -1056,9 +1059,9 @@
     },
     "vctrs": {
       "Package": "vctrs",
-      "Version": "0.6.2",
+      "Version": "0.6.3",
       "Source": "Repository",
-      "Repository": "RSPM",
+      "Repository": "CRAN",
       "Requirements": [
         "R",
         "cli",
@@ -1066,7 +1069,7 @@
         "lifecycle",
         "rlang"
       ],
-      "Hash": "a745bda7aff4734c17294bb41d4e4607"
+      "Hash": "d0ef2856b83dc33ea6e255caf6229ee2"
     },
     "viridisLite": {
       "Package": "viridisLite",
@@ -1082,7 +1085,7 @@
       "Package": "withr",
       "Version": "2.5.0",
       "Source": "Repository",
-      "Repository": "RSPM",
+      "Repository": "CRAN",
       "Requirements": [
         "R",
         "grDevices",
@@ -1093,25 +1096,25 @@
     },
     "xfun": {
       "Package": "xfun",
-      "Version": "0.39",
+      "Version": "0.40",
       "Source": "Repository",
-      "Repository": "RSPM",
+      "Repository": "CRAN",
       "Requirements": [
         "stats",
         "tools"
       ],
-      "Hash": "8f56e9acb54fb525e66464d57ab58bcb"
+      "Hash": "be07d23211245fc7d4209f54c4e4ffc8"
     },
     "xml2": {
       "Package": "xml2",
-      "Version": "1.3.4",
+      "Version": "1.3.5",
       "Source": "Repository",
       "Repository": "CRAN",
       "Requirements": [
         "R",
         "methods"
       ],
-      "Hash": "7dc765ac9b909487326a7d471fdd3821"
+      "Hash": "6c40e5cfcc6aefd88110666e18c31f40"
     },
     "yaml": {
       "Package": "yaml",

--- a/performance-release-report/renv.lock
+++ b/performance-release-report/renv.lock
@@ -30,11 +30,12 @@
     },
     "Matrix": {
       "Package": "Matrix",
-      "Version": "1.5-4.1",
+      "Version": "1.6-1",
       "Source": "Repository",
-      "Repository": "CRAN",
+      "Repository": "RSPM",
       "Requirements": [
         "R",
+        "grDevices",
         "graphics",
         "grid",
         "lattice",
@@ -42,7 +43,7 @@
         "stats",
         "utils"
       ],
-      "Hash": "38082d362d317745fb932e13956dccbb"
+      "Hash": "cb6855ac711958ca734b75e631b2035d"
     },
     "R6": {
       "Package": "R6",
@@ -66,37 +67,37 @@
     },
     "Rcpp": {
       "Package": "Rcpp",
-      "Version": "1.0.10",
+      "Version": "1.0.11",
       "Source": "Repository",
       "Repository": "RSPM",
       "Requirements": [
         "methods",
         "utils"
       ],
-      "Hash": "e749cae40fa9ef469b6050959517453c"
+      "Hash": "ae6cbbe1492f4de79c45fce06f967ce8"
     },
     "V8": {
       "Package": "V8",
-      "Version": "4.3.0",
+      "Version": "4.3.3",
       "Source": "Repository",
-      "Repository": "CRAN",
+      "Repository": "RSPM",
       "Requirements": [
         "Rcpp",
         "curl",
         "jsonlite",
         "utils"
       ],
-      "Hash": "d1fa8fae6a47e88bb46d5152312bd8bd"
+      "Hash": "20d81ec18bde233d8cc3265761fe8c93"
     },
     "askpass": {
       "Package": "askpass",
-      "Version": "1.1",
+      "Version": "1.2.0",
       "Source": "Repository",
-      "Repository": "CRAN",
+      "Repository": "RSPM",
       "Requirements": [
         "sys"
       ],
-      "Hash": "e8a22846fff485f0be3770c2da758713"
+      "Hash": "cad6cf7f1d5f6e906700b9d3e718c796"
     },
     "base64enc": {
       "Package": "base64enc",
@@ -127,7 +128,7 @@
     },
     "bslib": {
       "Package": "bslib",
-      "Version": "0.4.2",
+      "Version": "0.5.1",
       "Source": "Repository",
       "Repository": "RSPM",
       "Requirements": [
@@ -143,7 +144,7 @@
         "rlang",
         "sass"
       ],
-      "Hash": "a7fbf03946ad741129dc81098722fca1"
+      "Hash": "283015ddfbb9d7bf15ea9f0b5698f0d9"
     },
     "cachem": {
       "Package": "cachem",
@@ -239,7 +240,7 @@
     },
     "dplyr": {
       "Package": "dplyr",
-      "Version": "1.1.2",
+      "Version": "1.1.3",
       "Source": "Repository",
       "Repository": "RSPM",
       "Requirements": [
@@ -258,7 +259,7 @@
         "utils",
         "vctrs"
       ],
-      "Hash": "dea6970ff715ca541c387de363ff405e"
+      "Hash": "e85ffbebaad5f70e1a2e2ef4302b4949"
     },
     "ellipsis": {
       "Package": "ellipsis",
@@ -310,7 +311,7 @@
     },
     "fontawesome": {
       "Package": "fontawesome",
-      "Version": "0.5.1",
+      "Version": "0.5.2",
       "Source": "Repository",
       "Repository": "RSPM",
       "Requirements": [
@@ -318,7 +319,7 @@
         "htmltools",
         "rlang"
       ],
-      "Hash": "1e22b8cabbad1eae951a75e9f8b52378"
+      "Hash": "c2efdd5f0bcd1ea861c2d4e2a883a67d"
     },
     "forcats": {
       "Package": "forcats",
@@ -380,7 +381,7 @@
     },
     "ggplot2": {
       "Package": "ggplot2",
-      "Version": "3.4.2",
+      "Version": "3.4.3",
       "Source": "Repository",
       "Repository": "RSPM",
       "Requirements": [
@@ -401,7 +402,7 @@
         "vctrs",
         "withr"
       ],
-      "Hash": "3a147ee02e85a8941aad9909f1b43b7b"
+      "Hash": "85846544c596e71f8f46483ab165da33"
     },
     "glue": {
       "Package": "glue",
@@ -446,7 +447,7 @@
     },
     "gtable": {
       "Package": "gtable",
-      "Version": "0.3.3",
+      "Version": "0.3.4",
       "Source": "Repository",
       "Repository": "RSPM",
       "Requirements": [
@@ -457,7 +458,7 @@
         "lifecycle",
         "rlang"
       ],
-      "Hash": "b44addadb528a0d227794121c00572a0"
+      "Hash": "b29cf3031f49b04ab9c852c912547eef"
     },
     "highr": {
       "Package": "highr",
@@ -486,7 +487,7 @@
     },
     "htmltools": {
       "Package": "htmltools",
-      "Version": "0.5.5",
+      "Version": "0.5.6",
       "Source": "Repository",
       "Repository": "RSPM",
       "Requirements": [
@@ -499,7 +500,7 @@
         "rlang",
         "utils"
       ],
-      "Hash": "ba0240784ad50a62165058a27459304a"
+      "Hash": "a2326a66919a3311f7fbb1e3bf568283"
     },
     "htmlwidgets": {
       "Package": "htmlwidgets",
@@ -616,14 +617,14 @@
     },
     "labeling": {
       "Package": "labeling",
-      "Version": "0.4.2",
+      "Version": "0.4.3",
       "Source": "Repository",
       "Repository": "RSPM",
       "Requirements": [
         "graphics",
         "stats"
       ],
-      "Hash": "3d5108641f47470611a32d0bdf357a72"
+      "Hash": "b64ec208ac5bc1852b285f665d6368b3"
     },
     "lattice": {
       "Package": "lattice",
@@ -678,16 +679,16 @@
     },
     "markdown": {
       "Package": "markdown",
-      "Version": "1.7",
+      "Version": "1.8",
       "Source": "Repository",
-      "Repository": "CRAN",
+      "Repository": "RSPM",
       "Requirements": [
         "R",
         "commonmark",
         "utils",
         "xfun"
       ],
-      "Hash": "0ffaea87c070a56d140ce00b0727b278"
+      "Hash": "93cecf1e5f828d0fc1605a00ad48e3a2"
     },
     "memoise": {
       "Package": "memoise",
@@ -702,9 +703,9 @@
     },
     "mgcv": {
       "Package": "mgcv",
-      "Version": "1.8-42",
+      "Version": "1.9-0",
       "Source": "Repository",
-      "Repository": "CRAN",
+      "Repository": "RSPM",
       "Requirements": [
         "Matrix",
         "R",
@@ -715,7 +716,7 @@
         "stats",
         "utils"
       ],
-      "Hash": "3460beba7ccc8946249ba35327ba902a"
+      "Hash": "086028ca0460d0c368028d3bda58f31b"
     },
     "mime": {
       "Package": "mime",
@@ -740,9 +741,9 @@
     },
     "nlme": {
       "Package": "nlme",
-      "Version": "3.1-162",
+      "Version": "3.1-163",
       "Source": "Repository",
-      "Repository": "CRAN",
+      "Repository": "RSPM",
       "Requirements": [
         "R",
         "graphics",
@@ -750,7 +751,7 @@
         "stats",
         "utils"
       ],
-      "Hash": "0984ce8da8da9ead8643c5cbbb60f83e"
+      "Hash": "8d1938040a05566f4f7a14af4feadd6b"
     },
     "openssl": {
       "Package": "openssl",
@@ -841,13 +842,13 @@
     },
     "renv": {
       "Package": "renv",
-      "Version": "1.0.0",
+      "Version": "1.0.2",
       "Source": "Repository",
-      "Repository": "CRAN",
+      "Repository": "RSPM",
       "Requirements": [
         "utils"
       ],
-      "Hash": "c321cd99d56443dbffd1c9e673c0c1a2"
+      "Hash": "4b22ac016fe54028b88d0c68badbd061"
     },
     "rlang": {
       "Package": "rlang",
@@ -862,7 +863,7 @@
     },
     "rmarkdown": {
       "Package": "rmarkdown",
-      "Version": "2.21",
+      "Version": "2.24",
       "Source": "Repository",
       "Repository": "RSPM",
       "Requirements": [
@@ -882,11 +883,11 @@
         "xfun",
         "yaml"
       ],
-      "Hash": "493df4ae51e2e984952ea4d5c75786a3"
+      "Hash": "3854c37590717c08c32ec8542a2e0a35"
     },
     "sass": {
       "Package": "sass",
-      "Version": "0.4.6",
+      "Version": "0.4.7",
       "Source": "Repository",
       "Repository": "RSPM",
       "Requirements": [
@@ -896,7 +897,7 @@
         "rappdirs",
         "rlang"
       ],
-      "Hash": "cc3ec7dd33982ef56570229b62d6388e"
+      "Hash": "6bd4d33b50ff927191ec9acbf52fd056"
     },
     "scales": {
       "Package": "scales",
@@ -1077,13 +1078,13 @@
     },
     "tinytex": {
       "Package": "tinytex",
-      "Version": "0.45",
+      "Version": "0.46",
       "Source": "Repository",
       "Repository": "RSPM",
       "Requirements": [
         "xfun"
       ],
-      "Hash": "e4e357f28c2edff493936b6cb30c3d65"
+      "Hash": "0c41a73214d982f539c56a7773c7afa5"
     },
     "utf8": {
       "Package": "utf8",
@@ -1097,13 +1098,13 @@
     },
     "uuid": {
       "Package": "uuid",
-      "Version": "1.1-0",
+      "Version": "1.1-1",
       "Source": "Repository",
-      "Repository": "CRAN",
+      "Repository": "RSPM",
       "Requirements": [
         "R"
       ],
-      "Hash": "f1cb46c157d080b729159d407be83496"
+      "Hash": "3d78edfb977a69fc7a0341bee25e163f"
     },
     "vctrs": {
       "Package": "vctrs",

--- a/performance-release-report/renv.lock
+++ b/performance-release-report/renv.lock
@@ -470,6 +470,20 @@
       ],
       "Hash": "06230136b2d2b9ba5805e1963fa6e890"
     },
+    "hms": {
+      "Package": "hms",
+      "Version": "1.1.3",
+      "Source": "Repository",
+      "Repository": "CRAN",
+      "Requirements": [
+        "lifecycle",
+        "methods",
+        "pkgconfig",
+        "rlang",
+        "vctrs"
+      ],
+      "Hash": "b59377caa7ed00fa41808342002138f9"
+    },
     "htmltools": {
       "Package": "htmltools",
       "Version": "0.5.5",
@@ -531,6 +545,28 @@
         "utils"
       ],
       "Hash": "0080607b4a1a7b28979aecef976d8bc2"
+    },
+    "janitor": {
+      "Package": "janitor",
+      "Version": "2.2.0",
+      "Source": "Repository",
+      "Repository": "CRAN",
+      "Requirements": [
+        "R",
+        "dplyr",
+        "hms",
+        "lifecycle",
+        "lubridate",
+        "magrittr",
+        "purrr",
+        "rlang",
+        "snakecase",
+        "stringi",
+        "stringr",
+        "tidyr",
+        "tidyselect"
+      ],
+      "Hash": "5baae149f1082f466df9d1442ba7aa65"
     },
     "jquerylib": {
       "Package": "jquerylib",
@@ -902,6 +938,18 @@
         "utils"
       ],
       "Hash": "c12e756cf947e58b0f2c2a520521a5a8"
+    },
+    "snakecase": {
+      "Package": "snakecase",
+      "Version": "0.11.1",
+      "Source": "Repository",
+      "Repository": "CRAN",
+      "Requirements": [
+        "R",
+        "stringi",
+        "stringr"
+      ],
+      "Hash": "58767e44739b76965332e8a4fe3f91f1"
     },
     "stringi": {
       "Package": "stringi",

--- a/performance-release-report/renv/activate.R
+++ b/performance-release-report/renv/activate.R
@@ -2,11 +2,26 @@
 local({
 
   # the requested version of renv
-  version <- "1.0.0"
+  version <- "1.0.2"
   attr(version, "sha") <- NULL
 
   # the project directory
   project <- getwd()
+
+  # use start-up diagnostics if enabled
+  diagnostics <- Sys.getenv("RENV_STARTUP_DIAGNOSTICS", unset = "FALSE")
+  if (diagnostics) {
+    start <- Sys.time()
+    profile <- tempfile("renv-startup-", fileext = ".Rprof")
+    utils::Rprof(profile)
+    on.exit({
+      utils::Rprof(NULL)
+      elapsed <- signif(difftime(Sys.time(), start, units = "auto"), digits = 2L)
+      writeLines(sprintf("- renv took %s to run the autoloader.", format(elapsed)))
+      writeLines(sprintf("- Profile: %s", profile))
+      print(utils::summaryRprof(profile))
+    }, add = TRUE)
+  }
 
   # figure out whether the autoloader is enabled
   enabled <- local({
@@ -504,7 +519,7 @@ local({
   
     # open the bundle for reading
     # We use gzcon for everything because (from ?gzcon)
-    # > Reading from a connection which does not supply a ‘gzip’ magic
+    # > Reading from a connection which does not supply a 'gzip' magic
     # > header is equivalent to reading from the original connection
     conn <- gzcon(file(bundle, open = "rb", raw = TRUE))
     on.exit(close(conn))
@@ -767,10 +782,12 @@ local({
   renv_bootstrap_validate_version <- function(version, description = NULL) {
   
     # resolve description file
-    description <- description %||% {
-      path <- getNamespaceInfo("renv", "path")
-      packageDescription("renv", lib.loc = dirname(path))
-    }
+    #
+    # avoid passing lib.loc to `packageDescription()` below, since R will
+    # use the loaded version of the package by default anyhow. note that
+    # this function should only be called after 'renv' is loaded
+    # https://github.com/rstudio/renv/issues/1625
+    description <- description %||% packageDescription("renv")
   
     # check whether requested version 'version' matches loaded version of renv
     sha <- attr(version, "sha", exact = TRUE)
@@ -841,7 +858,7 @@ local({
     hooks <- getHook("renv::autoload")
     for (hook in hooks)
       if (is.function(hook))
-        tryCatch(hook(), error = warning)
+        tryCatch(hook(), error = warnify)
   
     # load the project
     renv::load(project)
@@ -982,10 +999,15 @@ local({
   
   }
   
-  renv_bootstrap_version_friendly <- function(version, sha = NULL) {
+  renv_bootstrap_version_friendly <- function(version, shafmt = NULL, sha = NULL) {
     sha <- sha %||% attr(version, "sha", exact = TRUE)
-    parts <- c(version, sprintf("[sha: %s]", substring(sha, 1L, 7L)))
-    paste(parts, collapse = " ")
+    parts <- c(version, sprintf(shafmt %||% " [sha: %s]", substring(sha, 1L, 7L)))
+    paste(parts, collapse = "")
+  }
+  
+  renv_bootstrap_exec <- function(project, libpath, version) {
+    if (!renv_bootstrap_load(project, libpath, version))
+      renv_bootstrap_run(version, libpath)
   }
   
   renv_bootstrap_run <- function(version, libpath) {
@@ -1015,6 +1037,14 @@ local({
   
   renv_bootstrap_in_rstudio <- function() {
     commandArgs()[[1]] == "RStudio"
+  }
+  
+  # Used to work around buglet in RStudio if hook uses readline
+  renv_bootstrap_flush_console <- function() {
+    tryCatch({
+      tools <- as.environment("tools:rstudio")
+      tools$.rs.api.sendToConsole("", echo = FALSE, focus = FALSE)
+    }, error = function(cnd) {})
   }
   
   renv_json_read <- function(file = NULL, text = NULL) {
@@ -1155,25 +1185,15 @@ local({
   # construct full libpath
   libpath <- file.path(root, prefix)
 
-  # attempt to load
-  if (renv_bootstrap_load(project, libpath, version))
-    return(TRUE)
-
   if (renv_bootstrap_in_rstudio()) {
+    # RStudio only updates console once .Rprofile is finished, so
+    # instead run code on sessionInit
     setHook("rstudio.sessionInit", function(...) {
-      renv_bootstrap_run(version, libpath)
-
-      # Work around buglet in RStudio if hook uses readline
-      tryCatch(
-        {
-          tools <- as.environment("tools:rstudio")
-          tools$.rs.api.sendToConsole("", echo = FALSE, focus = FALSE)
-        },
-        error = function(cnd) {}
-      )
+      renv_bootstrap_exec(project, libpath, version)
+      renv_bootstrap_flush_console()
     })
   } else {
-    renv_bootstrap_run(version, libpath)
+    renv_bootstrap_exec(project, libpath, version)
   }
 
   invisible()

--- a/performance-release-report/renv/activate.R
+++ b/performance-release-report/renv/activate.R
@@ -3,7 +3,7 @@ local({
 
   # the requested version of renv
   version <- "1.0.2"
-  attr(version, "sha") <- NULL
+  attr(version, "sha") <- "1.0.2"
 
   # the project directory
   project <- getwd()


### PR DESCRIPTION
This PR implements an interface to work with the microbenchmarks, include the C++ and Java ones. Additionally, because there are _so_ many, I've enabled the user to be able to filter for conbench detected regressions and improvements. I've followed the style of the other plots in this report though these one are built in Javascript. 

I have also added a link so users can go to conbench to directly view the compare page. 

@assignUser I would like to request a review from Ed (https://github.com/alistaire47) but I'm not actually able to tag him here. Are you able to do that? 

Attached is a zip file containing a rendered copy using the last release: 
[performance-release-report.html.zip](https://github.com/ursacomputing/crossbow/files/12529011/performance-release-report.html.zip). Reminder that this needs to be served up via http because of js libraries. 
