### PR TITLE
Fix release report location

### DIFF
--- a/.github/workflows/performance-release-report.yml
+++ b/.github/workflows/performance-release-report.yml
@@ -93,4 +93,4 @@ jobs:
           AWS_DEFAULT_REGION: ${{ secrets.CROSSBOW_DOCS_S3_BUCKET_REGION }}
           BUCKET: ${{ secrets.CROSSBOW_DOCS_S3_BUCKET }}
         run: |
-          aws s3 cp performance-release-report.html $BUCKET/performance-release-report${{ env.RC_LABEL }}.html
+          aws s3 cp performance-release-report.html $BUCKET/release_reports/arrow-release-report-${{ env.RC_LABEL }}.html


### PR DESCRIPTION
When testing the workflow I noticed that it is copied to the root: http://crossbow.voltrondata.com/performance-release-reportmanual.html

This adds a minor change to match the already published one: http://crossbow.voltrondata.com/release_reports/arrow-release-report-13.0.0-rc2.html

@boshek I will also send the above rebuild of the 13.0.0 report to the ml for feedback :+1: 