### PR TITLE
recreate run link

### DIFF
--- a/performance-release-report/performance-release-report.qmd
+++ b/performance-release-report/performance-release-report.qmd
@@ -123,6 +123,7 @@ micro_bm_df <- run_comp %>%
 ## extract hardware information
 hardware_summary <- run_comp %>%
   mutate(commit.timestamp = ymd_hms(commit.timestamp)) %>%
+  mutate(links.self = glue("https://conbench.ursa.dev/runs/{id}")) %>% 
   distinct(run_type, links.self, commit.sha, commit.timestamp, commit.url, hardware.cpu_model_name, id)
 
 if (nrow(hardware_summary) != 2L*length(hardware_name)) {


### PR DESCRIPTION
@assignUser: This fixes a small bug in this code to accommodate some changes in Conbench. The intent here is to still provide a link to a specify run. 