### PR TITLE
Bump Python versions

### DIFF
--- a/.github/workflows/nightly_dashboard.yml
+++ b/.github/workflows/nightly_dashboard.yml
@@ -36,7 +36,7 @@ jobs:
         uses: actions/setup-python@v4
         with:
           cache: pip
-          python-version: 3.11
+          python-version: 3.12
 
       - name: Generate List of Crossbow Tasks
         run: |
@@ -59,7 +59,7 @@ jobs:
 
       - name: Setup renv
         uses: r-lib/actions/setup-renv@v2
-        env: 
+        env:
           # This is set by setup-r
           RENV_CONFIG_REPOS_OVERRIDE: ""
         with:
@@ -90,4 +90,4 @@ jobs:
           AWS_DEFAULT_REGION: ${{ secrets.CROSSBOW_DOCS_S3_BUCKET_REGION }}
           BUCKET: ${{ secrets.CROSSBOW_DOCS_S3_BUCKET }}
         run: |
-          aws s3 cp crossbow-nightly-report/crossbow-nightly-report.html $BUCKET/index.html 
+          aws s3 cp crossbow-nightly-report/crossbow-nightly-report.html $BUCKET/index.html

--- a/.github/workflows/report.yml
+++ b/.github/workflows/report.yml
@@ -40,7 +40,7 @@ jobs:
           fetch-depth: 0
       - uses: actions/setup-python@v4
         with:
-          python-version: '3.8'
+          python-version: 3.12
       - name: Install Archery
         shell: bash
         run: pip install -e arrow/dev/archery[crossbow]

--- a/.github/workflows/submit.yml
+++ b/.github/workflows/submit.yml
@@ -9,7 +9,7 @@ on:
       date:
         required: false
         default: ''
-        type: string  
+        type: string
     secrets:
       CROSSBOW_GITHUB_TOKEN:
         required: true
@@ -28,7 +28,7 @@ jobs:
         run: git clone https://github.com/ursacomputing/crossbow
       - uses: actions/setup-python@v4
         with:
-          python-version: '3.8'
+          python-version: 3.12
       - name: Install Archery
         shell: bash
         run: pip install -e arrow/dev/archery[crossbow]

--- a/.github/workflows/token_expiration.yml
+++ b/.github/workflows/token_expiration.yml
@@ -30,7 +30,7 @@ jobs:
           fetch-depth: 0
       - uses: actions/setup-python@v4
         with:
-          python-version: '3.11'
+          python-version: 3.12
       - name: Install Archery
         shell: bash
         run: pip install -e arrow/dev/archery[crossbow]

--- a/.github/workflows/windows_docker.yml
+++ b/.github/workflows/windows_docker.yml
@@ -50,7 +50,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v4
         with:
-          python-version: 3.8
+          python-version: 3.12
 
       - name: Install Archery
         shell: bash


### PR DESCRIPTION
We need at least 3.9 to accommodate `archery[crossbow]` but I've bumped everything I could find to 3.12 to hopefully forestall using a very old version for longer.