### PR TITLE
MINOR: Fix trend plot

### DIFF
--- a/.github/workflows/nightly_dashboard.yml
+++ b/.github/workflows/nightly_dashboard.yml
@@ -46,7 +46,7 @@ jobs:
       - name: Setup Quarto
         uses: quarto-dev/quarto-actions/setup@v2
         with:
-          version: '1.3.450'
+          version: '1.4.549'
 
       - uses: r-lib/actions/setup-r@v2
         with:

--- a/crossbow-nightly-report/crossbow-nightly-report.qmd
+++ b/crossbow-nightly-report/crossbow-nightly-report.qmd
@@ -203,8 +203,6 @@ trendPlot = function(data) {
 ```
 
 ```{ojs setup-ojs}
-// import newer observable
-Plot = await import("https://esm.sh/@observablehq/plot");
 import { aq, op } from '@uwdata/arquero';
 parser = d3.timeParse("%Y-%m-%d");
 import {slider as slide} from "@jashkenas/inputs"; // more configurable slider
@@ -262,7 +260,7 @@ trendPlot(passPctDateSub)
 ```{r build_status}
 #| results: asis
 # this file can be generated with `archery crossbow check-config > all.yml`
-tasks <- yaml.load_file("../all.yml")
+tasks <- yaml.load_file("all.yml")
 
 tests <- tasks$groups[["nightly-tests"]]
 packaging <- tasks$groups[["nightly-packaging"]]

--- a/crossbow-nightly-report/crossbow-nightly-report.qmd
+++ b/crossbow-nightly-report/crossbow-nightly-report.qmd
@@ -260,7 +260,7 @@ trendPlot(passPctDateSub)
 ```{r build_status}
 #| results: asis
 # this file can be generated with `archery crossbow check-config > all.yml`
-tasks <- yaml.load_file("all.yml")
+tasks <- yaml.load_file("../all.yml")
 
 tests <- tasks$groups[["nightly-tests"]]
 packaging <- tasks$groups[["nightly-packaging"]]


### PR DESCRIPTION
This PR remove an esm installation of Observable Plot. Previously Quarto did not come bundled with that version of Plot which we needed for some features. It does now so we can bump quarto and remove the pin.

Fixes #80