### PR TITLE
MINOR: remove double units col

### DIFF
--- a/performance-release-report/R/functions.R
+++ b/performance-release-report/R/functions.R
@@ -144,7 +144,7 @@ tidy_compare <- function(.x, .y) {
   tag_names <- tag_names[!tag_names %in% c("baseline.tags.name", "baseline.tags.query_id", "baseline.tags.language", "baseline.tags.engine", "baseline.tags.memory_map", "baseline.tags.query", "baseline.tags.async")]
 
   plot_df <- .x %>%
-    select(-any_of(c("baseline.tags.dataset", "baseline.tags.language"))) %>%
+    select(-any_of(c("baseline.tags.dataset", "baseline.tags.language", "baseline.tags.unit"))) %>%
     rename_with(~ gsub("baseline.tags.", "", .)) %>%
     mutate(change = analysis.pairwise.percent_change) %>%
     mutate(difference = paste0(round((baseline.single_value_summary - contender.single_value_summary), 4), "", unit)) %>%


### PR DESCRIPTION
Closes #84 

With:

```
BASELINE_GIT_COMMIT=e03105efc38edca4ca429bf967a17b4d0fbebe40
CONTENDER_GIT_COMMIT=6a28035c2b49b432dc63f5ee7524d76b4ed2d762
```

This will fix report rendering. However, it is worth mentioning that this still will exclude the C++ benchmarks as those failed for the `6a28035c2b49b432dc63f5ee7524d76b4ed2d762` run. 

cc @raulcd and @assignUser 