### PR TITLE
FIX: move to ubuntu latest

### DIFF
--- a/.github/workflows/nightly_dashboard.yml
+++ b/.github/workflows/nightly_dashboard.yml
@@ -20,7 +20,7 @@ on:
 
 jobs:
   build:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     steps:
 
       - uses: actions/checkout@v4


### PR DESCRIPTION
I noticed that this job was failing. I think we can just run this on the latest right?

@assignUser 