### PR TITLE
FIX: add curl in the dashboard action

### DIFF
--- a/.github/workflows/nightly_dashboard.yml
+++ b/.github/workflows/nightly_dashboard.yml
@@ -32,6 +32,11 @@ jobs:
         with:
           path: crossbow
 
+      - name: Install system dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y libcurl4-openssl-dev          
+  
       - name: Set up Python
         uses: actions/setup-python@v5
         with:


### PR DESCRIPTION
Fixes #93 

There may be better ways to do this but just manually installing this works. cc @jonkeane @raulcd 